### PR TITLE
DR2-1168 feat: Replace DP with DR2

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -20,7 +20,7 @@ jobs:
     uses: nationalarchives/dr2-github-actions/.github/workflows/terraform_apply.yml@main
     needs: setup
     with:
-      repo-name: dp-terraform-environments
+      repo-name: dr2-terraform-environments
       environment: ${{ github.event.inputs.environment }}
       project: dr2
     secrets:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DP Terraform Environments
+# DR2 Terraform Environments
 
 ## Terraform Structure
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All of these files are run at once when terraform runs.
 
 ## Deployment
 
-To start a deployment, run the [DP Terraform Environments Deploy job in GitHub actions][github-actions-job] by clicking 'Run Workflow' and selecting the environment you want to deploy to. All changes must be deployed first to integration, then staging, then production.
+To start a deployment, run the [DR2 Terraform Environments Deploy job in GitHub actions][github-actions-job] by clicking 'Run Workflow' and selecting the environment you want to deploy to. All changes must be deployed first to integration, then staging, then production.
 
 The deployment will pause when Terraform has determined which changes need to be applied. Review the Terraform plan output by clicking the link provided in the Slack notification. This will be a link to Cloudwatch in the management account so you will need to be logged in to the management AWS account to use this.
 
@@ -24,7 +24,7 @@ Check whether the changes look correct, then open the actions approval page and 
 
 Deployments can be approved by anyone in the `digital-records-repository` GitHub team.
 
-[github-actions-job]: https://github.com/nationalarchives/dp-terraform-environments/actions/workflows/apply.yml
+[github-actions-job]: https://github.com/nationalarchives/dr2-terraform-environments/actions/workflows/apply.yml
 
 ## Elastic IPs
 Each environment has one elastic IP per AZ created manually within the AWS console and then used within terraform using `data "aws_eip"`
@@ -46,11 +46,11 @@ HCL Language Support: https://plugins.jetbrains.com/plugin/7808-hashicorp-terraf
 
 ## Running Terraform Project Locally
 
-**NOTE: Running Terraform locally should only be used to check the Terraform plan. Updating the DP environments should only ever be done through GitHub actions**
+**NOTE: Running Terraform locally should only be used to check the Terraform plan. Updating the DR2 environments should only ever be done through GitHub actions**
 
-1. Clone DP Environments project to local machine: https://github.com/nationalarchives/dp-terraform-environments and navigate to the directory
+1. Clone DR2 Environments project to local machine: https://github.com/nationalarchives/dr2-terraform-environments and navigate to the directory
 
-2. Switch to the Terraform workspace corresponding to the DP environment to be worked on:
+2. Switch to the Terraform workspace corresponding to the DR2 environment to be worked on:
 
    ```
    [location of project] $ terraform workspace select intg
@@ -58,14 +58,14 @@ HCL Language Support: https://plugins.jetbrains.com/plugin/7808-hashicorp-terraf
 
 3. Set the following Terraform environment variables on the local environment:
 
-    * TF_VAR_dp_account_number=*[account number of the environment to update]*
+    * TF_VAR_dr2_account_number=*[account number of the environment to update]*
 
 4. Initialize Terraform (if not done so previously):
 
 ```
 [location of project] $ terraform init   
 ```
-5. Run Terraform to view changes that will be made to the DP environment AWS resources
+5. Run Terraform to view changes that will be made to the DR2 environment AWS resources
 
 ```
 [location of project] $ terraform plan

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ HCL Language Support: https://plugins.jetbrains.com/plugin/7808-hashicorp-terraf
 
 3. Set the following Terraform environment variables on the local environment:
 
-    * TF_VAR_dr2_account_number=*[account number of the environment to update]*
+    * TF_VAR_account_number=*[account number of the environment to update]*
 
 4. Initialize Terraform (if not done so previously):
 

--- a/common.tf
+++ b/common.tf
@@ -48,7 +48,7 @@ data "aws_eip" "eip" {
 
 module "nat_instance_security_group" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//security_group"
-  common_tags = { CreatedBy = "dp-terraform-environments" }
+  common_tags = { CreatedBy = "dr2-terraform-environments" }
   description = "A security group to allow access to the NAT instance"
   name        = "${local.environment}-nat-instance-security-group"
   vpc_id      = module.vpc.vpc_id
@@ -67,7 +67,7 @@ module "nat_instance_security_group" {
 
 module "outbound_https_access_only" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//security_group"
-  common_tags = { CreatedBy = "dp-terraform-environments" }
+  common_tags = { CreatedBy = "dr2-terraform-environments" }
   description = "A security group to allow outbound access only"
   name        = "${local.environment}-outbound-https"
   vpc_id      = module.vpc.vpc_id
@@ -111,7 +111,7 @@ module "ingest_raw_cache_bucket" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
   bucket_name = local.ingest_raw_cache_bucket_name
   logging_bucket_policy = templatefile("./templates/s3/log_bucket_policy.json.tpl", {
-    bucket_name = "${local.ingest_raw_cache_bucket_name}-logs", account_id = var.dp_account_number
+    bucket_name = "${local.ingest_raw_cache_bucket_name}-logs", account_id = var.dr2_account_number
   })
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
     lambda_role_arn = module.ingest_parsed_court_document_event_handler_lambda.lambda_role_arn,

--- a/common.tf
+++ b/common.tf
@@ -111,7 +111,7 @@ module "ingest_raw_cache_bucket" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
   bucket_name = local.ingest_raw_cache_bucket_name
   logging_bucket_policy = templatefile("./templates/s3/log_bucket_policy.json.tpl", {
-    bucket_name = "${local.ingest_raw_cache_bucket_name}-logs", account_id = var.dr2_account_number
+    bucket_name = "${local.ingest_raw_cache_bucket_name}-logs", account_id = var.account_number
   })
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
     lambda_role_arn = module.ingest_parsed_court_document_event_handler_lambda.lambda_role_arn,

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -13,7 +13,7 @@ module "preservica_config_bucket" {
     bucket_name                       = local.preservica_config_bucket_name
   })
   logging_bucket_policy = templatefile("${path.module}/templates/s3/log_bucket_policy.json.tpl", {
-    bucket_name = "${local.preservica_config_bucket_name}-logs", account_id = var.dp_account_number
+    bucket_name = "${local.preservica_config_bucket_name}-logs", account_id = var.dr2_account_number
   })
 }
 
@@ -60,7 +60,7 @@ module "preservica_config_lambda" {
       secrets_manager_secret_arn = aws_secretsmanager_secret.preservica_secret.arn
       preservica_config_queue    = module.preservica_config_queue.sqs_arn
       bucket_name                = local.preservica_config_bucket_name
-      account_id                 = var.dp_account_number
+      account_id                 = var.dr2_account_number
       lambda_name                = local.preservica_config_lambda_name
     })
   }
@@ -76,6 +76,6 @@ module "preservica_config_lambda" {
   }
   tags = {
     Name      = local.preservica_config_lambda_name
-    CreatedBy = "dp-terraform-environments"
+    CreatedBy = "dr2-terraform-environments"
   }
 }

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -13,7 +13,7 @@ module "preservica_config_bucket" {
     bucket_name                       = local.preservica_config_bucket_name
   })
   logging_bucket_policy = templatefile("${path.module}/templates/s3/log_bucket_policy.json.tpl", {
-    bucket_name = "${local.preservica_config_bucket_name}-logs", account_id = var.dr2_account_number
+    bucket_name = "${local.preservica_config_bucket_name}-logs", account_id = var.account_number
   })
 }
 
@@ -60,7 +60,7 @@ module "preservica_config_lambda" {
       secrets_manager_secret_arn = aws_secretsmanager_secret.preservica_secret.arn
       preservica_config_queue    = module.preservica_config_queue.sqs_arn
       bucket_name                = local.preservica_config_bucket_name
-      account_id                 = var.dr2_account_number
+      account_id                 = var.account_number
       lambda_name                = local.preservica_config_lambda_name
     })
   }

--- a/disaster_recovery.tf
+++ b/disaster_recovery.tf
@@ -5,7 +5,7 @@ module "disaster_recovery_bucket" {
     CreatedBy = "dr2-terraform-environments"
   }
   logging_bucket_policy = templatefile("./templates/s3/log_bucket_policy.json.tpl", {
-    bucket_name = "${local.disaster_recovery_bucket_name}-logs", account_id = var.dr2_account_number
+    bucket_name = "${local.disaster_recovery_bucket_name}-logs", account_id = var.account_number
   })
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
     lambda_role_arn = module.download_metadata_and_files_lambda.lambda_role_arn,

--- a/disaster_recovery.tf
+++ b/disaster_recovery.tf
@@ -2,10 +2,10 @@ module "disaster_recovery_bucket" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
   bucket_name = local.disaster_recovery_bucket_name
   common_tags = {
-    CreatedBy = "dp-terraform-environments"
+    CreatedBy = "dr2-terraform-environments"
   }
   logging_bucket_policy = templatefile("./templates/s3/log_bucket_policy.json.tpl", {
-    bucket_name = "${local.disaster_recovery_bucket_name}-logs", account_id = var.dp_account_number
+    bucket_name = "${local.disaster_recovery_bucket_name}-logs", account_id = var.dr2_account_number
   })
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
     lambda_role_arn = module.download_metadata_and_files_lambda.lambda_role_arn,

--- a/download_metadata_and_files_lambda.tf
+++ b/download_metadata_and_files_lambda.tf
@@ -13,11 +13,11 @@ module "download_metadata_and_files_lambda" {
   }
   policies = {
     "${local.download_files_and_metadata_lambda_name}-policy" = templatefile("./templates/iam_policy/download_files_metadata_policy.json.tpl", {
-      secrets_manager_secret_arn   = "arn:aws:secretsmanager:eu-west-2:${var.dp_account_number}:secret:sandbox-preservica-6-preservicav6login-INFTcQ",
+      secrets_manager_secret_arn   = "arn:aws:secretsmanager:eu-west-2:${var.dr2_account_number}:secret:sandbox-preservica-6-preservicav6login-INFTcQ",
       download_files_sqs_queue_arn = module.download_files_sqs.sqs_arn
       disaster_recovery_bucket     = module.disaster_recovery_bucket
       bucket_name                  = local.disaster_recovery_bucket_name
-      account_id                   = var.dp_account_number
+      account_id                   = var.dr2_account_number
       lambda_name                  = local.download_files_and_metadata_lambda_name
     })
   }
@@ -34,7 +34,7 @@ module "download_metadata_and_files_lambda" {
   }
   tags = {
     Name      = local.download_files_and_metadata_lambda_name
-    CreatedBy = "dp-terraform-environments"
+    CreatedBy = "dr2-terraform-environments"
   }
 }
 
@@ -42,12 +42,12 @@ module "download_files_sqs" {
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = local.download_metadata_and_files_queue_name
   sqs_policy = templatefile("./templates/sqs/sqs_access_policy.json.tpl", {
-    account_id = var.dp_account_number, //TODO Restrict this to the SNS topic ARN when it's created
+    account_id = var.dr2_account_number, //TODO Restrict this to the SNS topic ARN when it's created
     queue_name = local.download_metadata_and_files_queue_name
   })
   redrive_maximum_receives = 3
   tags = {
-    CreatedBy = "dp-terraform-environments"
+    CreatedBy = "dr2-terraform-environments"
   }
   kms_key_id             = module.dr2_kms_key.kms_key_arn
   dlq_notification_topic = "arn:aws:sns:eu-west-2:${data.aws_caller_identity.current.account_id}:${local.environment}-dlq-notifications"

--- a/download_metadata_and_files_lambda.tf
+++ b/download_metadata_and_files_lambda.tf
@@ -13,11 +13,11 @@ module "download_metadata_and_files_lambda" {
   }
   policies = {
     "${local.download_files_and_metadata_lambda_name}-policy" = templatefile("./templates/iam_policy/download_files_metadata_policy.json.tpl", {
-      secrets_manager_secret_arn   = "arn:aws:secretsmanager:eu-west-2:${var.dr2_account_number}:secret:sandbox-preservica-6-preservicav6login-INFTcQ",
+      secrets_manager_secret_arn   = "arn:aws:secretsmanager:eu-west-2:${var.account_number}:secret:sandbox-preservica-6-preservicav6login-INFTcQ",
       download_files_sqs_queue_arn = module.download_files_sqs.sqs_arn
       disaster_recovery_bucket     = module.disaster_recovery_bucket
       bucket_name                  = local.disaster_recovery_bucket_name
-      account_id                   = var.dr2_account_number
+      account_id                   = var.account_number
       lambda_name                  = local.download_files_and_metadata_lambda_name
     })
   }
@@ -42,7 +42,7 @@ module "download_files_sqs" {
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = local.download_metadata_and_files_queue_name
   sqs_policy = templatefile("./templates/sqs/sqs_access_policy.json.tpl", {
-    account_id = var.dr2_account_number, //TODO Restrict this to the SNS topic ARN when it's created
+    account_id = var.account_number, //TODO Restrict this to the SNS topic ARN when it's created
     queue_name = local.download_metadata_and_files_queue_name
   })
   redrive_maximum_receives = 3

--- a/ingest_mapper.tf
+++ b/ingest_mapper.tf
@@ -9,7 +9,7 @@ module "ingest_mapper_lambda" {
   policies = {
     "${local.ingest_mapper_lambda_name}-policy" = templatefile("./templates/iam_policy/ingest_mapper_policy.json.tpl", {
       bucket_name   = local.ingest_raw_cache_bucket_name
-      account_id    = var.dp_account_number
+      account_id    = var.account_number
       lambda_name   = local.ingest_mapper_lambda_name
       dynamo_db_arn = module.files_table.table_arn
     })

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -9,7 +9,7 @@ module "ingest_parsed_court_document_event_handler_test_input_bucket" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
   bucket_name = local.ingest_parsed_court_document_event_handler_test_bucket_name
   logging_bucket_policy = templatefile("./templates/s3/log_bucket_policy.json.tpl", {
-    bucket_name = "${local.ingest_parsed_court_document_event_handler_test_bucket_name}-logs", account_id = var.dr2_account_number
+    bucket_name = "${local.ingest_parsed_court_document_event_handler_test_bucket_name}-logs", account_id = var.account_number
   })
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
     lambda_role_arn = module.ingest_parsed_court_document_event_handler_lambda.lambda_role_arn,
@@ -22,7 +22,7 @@ module "ingest_parsed_court_document_event_handler_sqs" {
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = local.ingest_parsed_court_document_event_handler_queue_name
   sqs_policy = templatefile("./templates/sqs/sqs_access_policy.json.tpl", {
-    account_id = var.dr2_account_number, //TODO Restrict this to the SNS topic ARN when it's created
+    account_id = var.account_number, //TODO Restrict this to the SNS topic ARN when it's created
     queue_name = local.ingest_parsed_court_document_event_handler_queue_name
   })
   redrive_maximum_receives = 5
@@ -43,7 +43,7 @@ module "ingest_parsed_court_document_event_handler_lambda" {
     "${local.ingest_parsed_court_document_event_handler_lambda_name}-policy" = templatefile("./templates/iam_policy/ingest_parsed_court_document_event_handler_lambda_policy.json.tpl", {
       ingest_parsed_court_document_event_handler_queue_arn = module.ingest_parsed_court_document_event_handler_sqs.sqs_arn
       bucket_name                                          = local.ingest_raw_cache_bucket_name
-      account_id                                           = var.dr2_account_number
+      account_id                                           = var.account_number
       lambda_name                                          = local.ingest_parsed_court_document_event_handler_lambda_name
       step_function_arn                                    = module.pre_ingest_step_function.step_function_arn
     })

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -9,7 +9,7 @@ module "ingest_parsed_court_document_event_handler_test_input_bucket" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
   bucket_name = local.ingest_parsed_court_document_event_handler_test_bucket_name
   logging_bucket_policy = templatefile("./templates/s3/log_bucket_policy.json.tpl", {
-    bucket_name = "${local.ingest_parsed_court_document_event_handler_test_bucket_name}-logs", account_id = var.dp_account_number
+    bucket_name = "${local.ingest_parsed_court_document_event_handler_test_bucket_name}-logs", account_id = var.dr2_account_number
   })
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
     lambda_role_arn = module.ingest_parsed_court_document_event_handler_lambda.lambda_role_arn,
@@ -22,7 +22,7 @@ module "ingest_parsed_court_document_event_handler_sqs" {
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = local.ingest_parsed_court_document_event_handler_queue_name
   sqs_policy = templatefile("./templates/sqs/sqs_access_policy.json.tpl", {
-    account_id = var.dp_account_number, //TODO Restrict this to the SNS topic ARN when it's created
+    account_id = var.dr2_account_number, //TODO Restrict this to the SNS topic ARN when it's created
     queue_name = local.ingest_parsed_court_document_event_handler_queue_name
   })
   redrive_maximum_receives = 5
@@ -43,7 +43,7 @@ module "ingest_parsed_court_document_event_handler_lambda" {
     "${local.ingest_parsed_court_document_event_handler_lambda_name}-policy" = templatefile("./templates/iam_policy/ingest_parsed_court_document_event_handler_lambda_policy.json.tpl", {
       ingest_parsed_court_document_event_handler_queue_arn = module.ingest_parsed_court_document_event_handler_sqs.sqs_arn
       bucket_name                                          = local.ingest_raw_cache_bucket_name
-      account_id                                           = var.dp_account_number
+      account_id                                           = var.dr2_account_number
       lambda_name                                          = local.ingest_parsed_court_document_event_handler_lambda_name
       step_function_arn                                    = module.pre_ingest_step_function.step_function_arn
     })
@@ -56,6 +56,6 @@ module "ingest_parsed_court_document_event_handler_lambda" {
   }
   tags = {
     Name      = local.ingest_parsed_court_document_event_handler_lambda_name
-    CreatedBy = "dp-terraform-environments"
+    CreatedBy = "dr2-terraform-environments"
   }
 }

--- a/root_provider.tf
+++ b/root_provider.tf
@@ -15,14 +15,14 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn     = "arn:aws:iam::${var.dp_account_number}:role/${local.environment_title}TerraformRole"
+    role_arn     = "arn:aws:iam::${var.dr2_account_number}:role/${local.environment_title}TerraformRole"
     session_name = "terraform"
     external_id  = module.config.terraform_config[local.environment]["terraform_external_id"]
   }
   default_tags {
     tags = {
       Environment = local.environment
-      CreatedBy   = "dp-terraform-environments"
+      CreatedBy   = "dr2-terraform-environments"
     }
   }
 }

--- a/root_provider.tf
+++ b/root_provider.tf
@@ -15,7 +15,7 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn     = "arn:aws:iam::${var.dr2_account_number}:role/${local.environment_title}TerraformRole"
+    role_arn     = "arn:aws:iam::${var.account_number}:role/${local.environment_title}TerraformRole"
     session_name = "terraform"
     external_id  = module.config.terraform_config[local.environment]["terraform_external_id"]
   }

--- a/root_variables.tf
+++ b/root_variables.tf
@@ -1,4 +1,4 @@
-variable "dp_account_number" {
+variable "dr2_account_number" {
   description = "The AWS account number where the DP environment is hosted"
   type        = string
 }

--- a/root_variables.tf
+++ b/root_variables.tf
@@ -1,4 +1,4 @@
-variable "dr2_account_number" {
+variable "account_number" {
   description = "The AWS account number where the DP environment is hosted"
   type        = string
 }

--- a/slack_notifications_lambda.tf
+++ b/slack_notifications_lambda.tf
@@ -12,7 +12,7 @@ module "slack_notifications_lambda" {
   policies = {
     "${local.notifications_lambda_name}-policy" = templatefile("./templates/iam_policy/slack_notifications_policy.json.tpl", {
       ssm_parameter_arn  = data.aws_ssm_parameter.slack_webhook_url.arn,
-      account_id         = var.dr2_account_number
+      account_id         = var.account_number
       lambda_name        = local.notifications_lambda_name
       notification_queue = module.cloudwatch_alarms_notifications_queue.sqs_arn
     })

--- a/slack_notifications_lambda.tf
+++ b/slack_notifications_lambda.tf
@@ -12,7 +12,7 @@ module "slack_notifications_lambda" {
   policies = {
     "${local.notifications_lambda_name}-policy" = templatefile("./templates/iam_policy/slack_notifications_policy.json.tpl", {
       ssm_parameter_arn  = data.aws_ssm_parameter.slack_webhook_url.arn,
-      account_id         = var.dp_account_number
+      account_id         = var.dr2_account_number
       lambda_name        = local.notifications_lambda_name
       notification_queue = module.cloudwatch_alarms_notifications_queue.sqs_arn
     })
@@ -27,6 +27,6 @@ module "slack_notifications_lambda" {
   }
   tags = {
     Name      = local.notifications_lambda_name
-    CreatedBy = "dp-terraform-environments"
+    CreatedBy = "dr2-terraform-environments"
   }
 }


### PR DESCRIPTION
I've updated the README and the GitHub workflow files with the new name.
I've also renamed dp_account_number to account_number. This then matches other non-dr2 terraform repos so we can use the same shared job.

I've not changed the state buckets because then we'd have to migrate the state and I don't think it's confusing anyone.