### PR TITLE
Add ingest raw staging bucket.

### DIFF
--- a/disaster_recovery.tf
+++ b/disaster_recovery.tf
@@ -8,8 +8,8 @@ module "disaster_recovery_bucket" {
     bucket_name = "${local.disaster_recovery_bucket_name}-logs", account_id = var.account_number
   })
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
-    lambda_role_arn = module.download_metadata_and_files_lambda.lambda_role_arn,
-    bucket_name     = local.disaster_recovery_bucket_name
+    lambda_role_arns = jsonencode([module.download_metadata_and_files_lambda.lambda_role_arn]),
+    bucket_name      = local.disaster_recovery_bucket_name
   })
   kms_key_arn = module.dr2_kms_key.kms_key_arn
 }

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -12,8 +12,8 @@ module "ingest_parsed_court_document_event_handler_test_input_bucket" {
     bucket_name = "${local.ingest_parsed_court_document_event_handler_test_bucket_name}-logs", account_id = var.account_number
   })
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
-    lambda_role_arn = module.ingest_parsed_court_document_event_handler_lambda.lambda_role_arn,
-    bucket_name     = local.ingest_parsed_court_document_event_handler_test_bucket_name
+    lambda_role_arns = jsonencode([module.ingest_parsed_court_document_event_handler_lambda.lambda_role_arn]),
+    bucket_name      = local.ingest_parsed_court_document_event_handler_test_bucket_name
   })
   kms_key_arn = module.dr2_kms_key.kms_key_arn
 }

--- a/templates/s3/lambda_access_bucket_policy.json.tpl
+++ b/templates/s3/lambda_access_bucket_policy.json.tpl
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${lambda_role_arn}"
+        "AWS": ${lambda_role_arns}
       },
       "Action": [
         "s3:GetObject",


### PR DESCRIPTION
This bucket will probably have more than one lambda accessing it so I've
changed the lambda bucket policy template to accept an array instead of
a single lambda. I've updated the other buckets that use this template.

This has no effect at the moment because the account has access to the
bucket by default but if we want to change the policy to a deny unless
style one later, this will help.

The raw cache bucket has already been created under another PR.
