### PR TITLE
Add asset_opex_creator to deploy role

### DIFF
--- a/deploy_roles.tf
+++ b/deploy_roles.tf
@@ -16,7 +16,8 @@ module "deploy_lambda_policy" {
       module.download_metadata_and_files_lambda.lambda_arn,
       module.slack_notifications_lambda.lambda_arn,
       module.entity_event_generator_lambda.lambda_arn,
-      module.ingest_mapper_lambda.lambda_arn
+      module.ingest_mapper_lambda.lambda_arn,
+      module.ingest_asset_opex_creator_lambda.lambda_arn
     ])
     bucket_name = "mgmt-dp-code-deploy"
   })


### PR DESCRIPTION
This allows GitHub actions to deploy the lambda. I missed it in the
original terraform PR.
