### PR TITLE
DR2 1217 add put events policy

### DIFF
--- a/templates/iam_policy/ingest_upsert_archives_folder_policy.json.tpl
+++ b/templates/iam_policy/ingest_upsert_archives_folder_policy.json.tpl
@@ -1,6 +1,12 @@
 {
   "Statement": [
     {
+      "Action": "events:PutEvents",
+      "Effect": "Allow",
+      "Resource": "arn:aws:events:eu-west-2:${account_id}:event-bus/default",
+      "Sid": "putEventbridgeEvents"
+    },
+    {
       "Action": "dynamodb:BatchGetItem",
       "Effect": "Allow",
       "Resource": "${dynamo_db_arn}",


### PR DESCRIPTION
Add put events to upsert lambda.
Also update the da-configurations hash. The changes are from other teams so don't affect us but it's nice to keep it up to date.
