### PR TITLE
Update entity event generator policy.

### DIFF
--- a/templates/iam_policy/entity_event_lambda_policy.json.tpl
+++ b/templates/iam_policy/entity_event_lambda_policy.json.tpl
@@ -3,7 +3,7 @@
     {
       "Action": [
         "dynamodb:UpdateItem",
-        "dynamodb:GetItem"
+        "dynamodb:BatchGetItem"
       ],
       "Effect": "Allow",
       "Resource": "${dynamo_db_arn}",


### PR DESCRIPTION
The AWS client is now using BatchGetItem instead of GetItem so the
policy needs changing.
