### PR TITLE
Small fixes to allow testing on staging.

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -3,7 +3,7 @@ locals {
   ingest_raw_cache_bucket_name            = "${local.environment}-dr2-ingest-raw-cache"
   ingest_staging_cache_bucket_name        = "${local.environment}-dr2-ingest-staging-cache"
   ingest_step_function_name               = "${local.environment_title}-ingest"
-  additional_user_roles                   = local.environment == "intg" ? [data.aws_ssm_parameter.dev_admin_role.value] : []
+  additional_user_roles                   = local.environment != "prod" ? [data.aws_ssm_parameter.dev_admin_role.value] : []
   files_dynamo_table_name                 = "${local.environment}-dr2-files"
   files_table_global_secondary_index_name = "BatchParentPathIdx"
 }

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -1,11 +1,11 @@
 locals {
   ingest_parsed_court_document_event_handler_queue_name       = "${local.environment}-ingest-parsed-court-document-event-handler"
-  ingest_parsed_court_document_event_handler_test_bucket_name = "${local.environment}-ingest-parsed-court-document-event-handler-test-input"
+  ingest_parsed_court_document_event_handler_test_bucket_name = "${local.environment}-ingest-parsed-court-document-test-input"
   ingest_parsed_court_document_event_handler_lambda_name      = "${local.environment}-ingest-parsed-court-document-event-handler"
 }
 
 module "ingest_parsed_court_document_event_handler_test_input_bucket" {
-  count       = local.environment == "intg" ? 1 : 0
+  count       = local.environment != "prod" ? 1 : 0
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
   bucket_name = local.ingest_parsed_court_document_event_handler_test_bucket_name
   logging_bucket_policy = templatefile("./templates/s3/log_bucket_policy.json.tpl", {


### PR DESCRIPTION
The first is to allow the admin role to use the KMS key which lets us
put and get stuff from the test input bucket.

The second is to shorten the name of the bucket because
staging-ingest-parsed-court-document-event-handler-test-input-logs is
too long. We may not need individual log buckets in the future but for
now, this will do.
