### PR TITLE
DR2-1276 Add delete permissions.

### DIFF
--- a/templates/iam_policy/ingest_parsed_court_document_event_handler_lambda_policy.json.tpl
+++ b/templates/iam_policy/ingest_parsed_court_document_event_handler_lambda_policy.json.tpl
@@ -21,7 +21,8 @@
     {
       "Action": [
         "s3:PutObject*",
-        "s3:GetObject"
+        "s3:GetObject",
+        "s3:DeleteObject"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
The court document lambda needs to delete its temporary files from the
top level of the raw cache bucket. The code to do the delete is deployed
but it needs an extra permission.
