### PR TITLE
Add dollar sign

### DIFF
--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -139,7 +139,7 @@
       "Resource": "arn:aws:states:::lambda:invoke",
       "OutputPath": "$.Payload",
       "Parameters": {
-        "FunctionName": "arn:aws:lambda:eu-west-2:{account_id}:function:${ingest_start_workflow_lambda_name}",
+        "FunctionName": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_start_workflow_lambda_name}",
         "Payload.$": "$"
       },
       "Retry": [


### PR DESCRIPTION
Without the dollar sign it was showing {account_id} rather than the
account id. This should work now.
