### PR TITLE
DR2-1391 Increase S3 copy lambda memory

### DIFF
--- a/s3_copy.tf
+++ b/s3_copy.tf
@@ -15,7 +15,7 @@ module "s3_copy_lambda" {
     })
   }
   timeout_seconds = 180
-  memory_size     = local.java_lambda_memory_size
+  memory_size     = 1024
   runtime         = local.java_runtime
   tags            = {}
   plaintext_env_vars = {


### PR DESCRIPTION
Sometimes, the s3 copy lambda is running out of memory.
As this is hopefully a temporary lambda, I don’t want to
spend time working out why so we just need to increase it.

I’ve tried it at 1024Mb and that works.