### PR TITLE
DR2-1363 Add eventbridge rule for security hub.

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -301,3 +301,20 @@ module "general_slack_message_eventbridge_rule" {
     })
   }
 }
+
+module "security_hub_eventbridge_rule" {
+  source              = "git::https://github.com/nationalarchives/da-terraform-modules//eventbridge_api_destination_rule"
+  api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
+  event_pattern       = templatefile("${path.module}/templates/eventbridge/security_hub_event_pattern.json.tpl", {})
+  name                = "${local.environment}-security-hub"
+  input_transformer = {
+    input_paths = {
+      "id" : "$.detail.findings[0].Resources[0].Id",
+      "title" : "$.detail.findings[0].Title"
+    }
+    input_template = templatefile("${path.module}/templates/eventbridge/slack_message_input_template.json.tpl", {
+      channel_id   = local.dev_notifications_channel_id
+      slackMessage = ":alert-noflash-slow: Security Hub finding for `<id>` <title>"
+    })
+  }
+}

--- a/templates/eventbridge/security_hub_event_pattern.json.tpl
+++ b/templates/eventbridge/security_hub_event_pattern.json.tpl
@@ -1,0 +1,4 @@
+{
+  "source": ["aws.securityhub"],
+  "detail-type": ["Security Hub Findings - Imported"]
+}


### PR DESCRIPTION
This will trigger when findings are imported or updated in Security Hub.

We'll have to see if this works and whether it's too chatty to be any
user.
