### PR TITLE
DR2-1225 Fix KMS policies and bucket name

### DIFF
--- a/anonymiser.tf
+++ b/anonymiser.tf
@@ -4,16 +4,17 @@ locals {
   tre_terraform_prod_config             = module.tre_config.terraform_config["prod"]
 }
 module "court_document_package_anonymiser_lambda" {
+  count           = local.environment == "intg" ? 1 : 0
   source          = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"
   function_name   = local.court_document_anonymiser_lambda_name
   handler         = "bootstrap"
   timeout_seconds = 30
   lambda_sqs_queue_mappings = {
-    court_document_package_anonymiser_queue = module.court_document_package_anonymiser_sqs.sqs_arn
+    court_document_package_anonymiser_queue = module.court_document_package_anonymiser_sqs[count.index].sqs_arn
   }
   policies = {
     "${local.court_document_anonymiser_lambda_name}-policy" = templatefile("./templates/iam_policy/anonymiser_lambda_policy.json.tpl", {
-      anonymiser_test_input_queue         = module.court_document_package_anonymiser_sqs.sqs_arn
+      anonymiser_test_input_queue         = module.court_document_package_anonymiser_sqs[count.index].sqs_arn
       ingest_court_document_handler_queue = module.ingest_parsed_court_document_event_handler_sqs.sqs_arn
       output_bucket_name                  = local.ingest_parsed_court_document_event_handler_test_bucket_name
       account_id                          = var.account_number
@@ -32,6 +33,7 @@ module "court_document_package_anonymiser_lambda" {
 }
 
 module "court_document_package_anonymiser_sqs" {
+  count      = local.environment == "intg" ? 1 : 0
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = local.court_document_anonymiser_queue_name
   sqs_policy = templatefile("./templates/sqs/sns_send_message_policy.json.tpl", {
@@ -46,7 +48,7 @@ module "court_document_package_anonymiser_sqs" {
 
 resource "aws_sns_topic_subscription" "tre_topic_subscription" {
   count                = local.environment == "intg" ? 1 : 0
-  endpoint             = module.court_document_package_anonymiser_sqs.sqs_arn
+  endpoint             = module.court_document_package_anonymiser_sqs[count.index].sqs_arn
   protocol             = "sqs"
   topic_arn            = local.tre_terraform_prod_config["da_eventbus"]
   raw_message_delivery = true

--- a/common.tf
+++ b/common.tf
@@ -5,6 +5,7 @@ locals {
   ingest_staging_cache_bucket_name        = "${local.environment}-dr2-ingest-staging-cache"
   ingest_step_function_name               = "${local.environment_title}-ingest"
   additional_user_roles                   = local.environment != "prod" ? [data.aws_ssm_parameter.dev_admin_role.value] : []
+  anonymiser_roles                        = local.environment == "intg" ? [module.court_document_package_anonymiser_lambda[0].lambda_role_arn] : []
   files_dynamo_table_name                 = "${local.environment}-dr2-files"
   files_table_global_secondary_index_name = "BatchParentPathIdx"
   dev_notifications_channel_id            = "C052LJASZ08"
@@ -96,9 +97,8 @@ module "dr2_kms_key" {
       module.e2e_tests_ecs_task_role.role_arn,
       module.copy_tna_to_preservica_role.role_arn,
       local.tre_prod_judgment_role,
-      module.s3_copy_lambda.lambda_role_arn,
-      module.court_document_package_anonymiser_lambda.lambda_role_arn
-    ], local.additional_user_roles)
+      module.s3_copy_lambda.lambda_role_arn
+    ], local.additional_user_roles, local.anonymiser_roles)
     ci_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.environment_title}TerraformRole"]
     service_details = [
       { service_name = "cloudwatch" },

--- a/common.tf
+++ b/common.tf
@@ -104,8 +104,8 @@ module "dr2_kms_key" {
       { service_name = "cloudwatch" },
       { service_name = "sns", service_source_account = module.tre_config.account_numbers["prod"] },
       { service_name = "sns" },
+      { service_name = "logs.eu-west-2" }
     ]
-    service_names = ["cloudwatch", "sns"]
   }
 }
 
@@ -117,8 +117,13 @@ module "dr2_developer_key" {
       data.aws_ssm_parameter.dev_admin_role.value,
       module.preservica_config_lambda.lambda_role_arn
     ]
-    ci_roles      = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.environment_title}TerraformRole"]
-    service_names = ["s3", "sns", "logs.eu-west-2", "cloudwatch"]
+    ci_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.environment_title}TerraformRole"]
+    service_details = [
+      { service_name = "cloudwatch" },
+      { service_name = "sns", service_source_account = module.tre_config.account_numbers["prod"] },
+      { service_name = "sns" },
+      { service_name = "logs.eu-west-2" }
+    ]
   }
 }
 

--- a/deploy_roles.tf
+++ b/deploy_roles.tf
@@ -1,3 +1,6 @@
+locals {
+  anonymiser_arn = local.environment == "intg" ? [module.court_document_package_anonymiser_lambda[0].lambda_arn] : []
+}
 module "deploy_lambda_role" {
   source             = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dr2-*" })
@@ -12,7 +15,7 @@ module "deploy_lambda_policy" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_policy"
   name   = "${local.environment_title}DPGithubActionsDeployLambdaPolicy"
   policy_string = templatefile("${path.module}/templates/iam_policy/deploy_lambda_policy.json.tpl", {
-    lambda_arns = jsonencode([
+    lambda_arns = jsonencode(concat([
       module.download_metadata_and_files_lambda.lambda_arn,
       module.ip_lock_checker_lambda.lambda_arn,
       module.ingest_parsed_court_document_event_handler_lambda.lambda_arn,
@@ -23,9 +26,8 @@ module "deploy_lambda_policy" {
       module.ingest_upsert_archive_folders_lambda.lambda_arn,
       module.ingest_parent_folder_opex_creator_lambda.lambda_arn,
       module.ingest_start_workflow_lambda.lambda_arn,
-      module.s3_copy_lambda.lambda_arn,
-      module.court_document_package_anonymiser_lambda.lambda_arn
-    ])
+      module.s3_copy_lambda.lambda_arn
+    ], local.anonymiser_arn))
     bucket_name = "mgmt-dp-code-deploy"
   })
 }

--- a/download_metadata_and_files_lambda.tf
+++ b/download_metadata_and_files_lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  disaster_recovery_bucket_name           = "${local.environment}-disaster-recovery"
+  disaster_recovery_bucket_name           = "${local.environment}-dr2-disaster-recovery"
   download_files_and_metadata_lambda_name = "${local.environment}-download-files-and-metadata"
   download_metadata_and_files_queue_name  = "${local.environment}-download-files-and-metadata"
 }


### PR DESCRIPTION
The bucket name had to be changed because sadly, prod-disaster-recovery
is taken.

The dev kms key was still using the old service_names parameter which
didn't do anything. I've updated it to use the service_details variable
which does.

I've also added the cloudwatch logs service to the main key. We're not
currently using it but we probably will.

I've removed the anonymiser lambda and queue for environments that weren't integration. They weren't connected to anything but it's a bit pointless having them around doing nothing.