### PR TITLE
DR2-1420 use new SQS mappings variable.

### DIFF
--- a/anonymiser.tf
+++ b/anonymiser.tf
@@ -8,9 +8,9 @@ module "court_document_package_anonymiser_lambda" {
   function_name   = local.court_document_anonymiser_lambda_name
   handler         = "bootstrap"
   timeout_seconds = 30
-  lambda_sqs_queue_mappings = {
-    court_document_package_anonymiser_queue = module.court_document_package_anonymiser_sqs.sqs_arn
-  }
+  lambda_sqs_queue_mappings = [{
+    sqs_queue_arn = module.court_document_package_anonymiser_sqs.sqs_arn
+  }]
   policies = {
     "${local.court_document_anonymiser_lambda_name}-policy" = templatefile("./templates/iam_policy/anonymiser_lambda_policy.json.tpl", {
       anonymiser_test_input_queue         = module.court_document_package_anonymiser_sqs.sqs_arn

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -47,9 +47,9 @@ module "preservica_config_lambda" {
   source        = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"
   function_name = local.preservica_config_lambda_name
   handler       = "uk.gov.nationalarchives.dp.Lambda::handleRequest"
-  lambda_sqs_queue_mappings = {
-    preservica_config_queue = module.preservica_config_queue.sqs_arn
-  }
+  lambda_sqs_queue_mappings = [{
+    sqs_queue_arn = module.preservica_config_queue.sqs_arn
+  }]
   timeout_seconds       = 60
   log_group_kms_key_arn = module.dr2_developer_key.kms_key_arn
   policies = {

--- a/download_metadata_and_files_lambda.tf
+++ b/download_metadata_and_files_lambda.tf
@@ -8,9 +8,9 @@ module "download_metadata_and_files_lambda" {
   source        = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"
   function_name = local.download_files_and_metadata_lambda_name
   handler       = "uk.gov.nationalarchives.Lambda::handleRequest"
-  lambda_sqs_queue_mappings = {
-    download_files_queue = module.download_files_sqs.sqs_arn
-  }
+  lambda_sqs_queue_mappings = [{
+    sqs_queue_arn = module.download_files_sqs.sqs_arn
+  }]
   policies = {
     "${local.download_files_and_metadata_lambda_name}-policy" = templatefile("./templates/iam_policy/download_files_metadata_policy.json.tpl", {
       secrets_manager_secret_arn   = "arn:aws:secretsmanager:eu-west-2:${var.account_number}:secret:sandbox-preservica-6-preservicav6login-INFTcQ",

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -3,6 +3,7 @@ locals {
   ingest_parsed_court_document_event_handler_test_bucket_name = "${local.environment}-ingest-parsed-court-document-test-input"
   ingest_parsed_court_document_event_handler_lambda_name      = "${local.environment}-ingest-parsed-court-document-event-handler"
   court_document_lambda_policy_template_suffix                = local.environment == "prod" ? "_prod" : ""
+  court_document_queue_sqs_policy                             = local.environment == "prod" ? "sns_send_message_policy" : "sqs_access_policy"
   tre_prod_event_bus                                          = local.tre_terraform_prod_config["da_eventbus"]
 }
 
@@ -38,7 +39,7 @@ module "copy_from_tre_bucket_policy" {
 module "ingest_parsed_court_document_event_handler_sqs" {
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = local.ingest_parsed_court_document_event_handler_queue_name
-  sqs_policy = templatefile("./templates/sqs/sns_send_message_policy.json.tpl", {
+  sqs_policy = templatefile("./templates/sqs/${local.court_document_queue_sqs_policy}.json.tpl", {
     account_id = var.account_number,
     queue_name = local.ingest_parsed_court_document_event_handler_queue_name
     topic_arn  = local.tre_prod_event_bus

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -50,9 +50,9 @@ module "ingest_parsed_court_document_event_handler_lambda" {
   function_name   = local.ingest_parsed_court_document_event_handler_lambda_name
   handler         = "uk.gov.nationalarchives.Lambda::handleRequest"
   timeout_seconds = 30
-  lambda_sqs_queue_mappings = {
-    ingest_parsed_court_document_event_handler_queue = module.ingest_parsed_court_document_event_handler_sqs.sqs_arn
-  }
+  lambda_sqs_queue_mappings = [
+    { sqs_queue_arn = module.ingest_parsed_court_document_event_handler_sqs.sqs_arn, ignore_enabled_status = true }
+  ]
   policies = {
     "${local.ingest_parsed_court_document_event_handler_lambda_name}-policy" = templatefile("./templates/iam_policy/ingest_parsed_court_document_event_handler_lambda_policy.json.tpl", {
       ingest_parsed_court_document_event_handler_queue_arn = module.ingest_parsed_court_document_event_handler_sqs.sqs_arn


### PR DESCRIPTION
This change allows us to ignore any manual changes to the status of the
queue mappings.

This depends on https://github.com/nationalarchives/da-terraform-modules/pull/33 The tests won't pass until this is merged.
