### PR TITLE
DR2-1419 Update upsert lambda retries.

### DIFF
--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -31,9 +31,9 @@
             "Lambda.SdkClientException",
             "Lambda.TooManyRequestsException"
           ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 10,
-          "BackoffRate": 4
+          "IntervalSeconds": 5,
+          "MaxAttempts": 15,
+          "BackoffRate": 1
         }
       ],
       "Next": "Map over each Asset Id",


### PR DESCRIPTION
The way it was set with a interval of 2 and a backoff rate of 4 meant
that we could be waiting around 9 days for an ingest to complete which
wouldn't work.

What we need is for it to try a lot of times in quick succession. Once
the initial 30s run from a cold lambda is done, the execution time of
the upsert lambda is ~1s.

These settings will try every 5 seconds up to 15 times so up to 75
seconds in total. This should give us plenty of time to process quite a
few concurrent step functions before we hit the max retries.

This could all be wrong though. All we can do is try it and see what
comes out of the testing later.
