### PR TITLE
DR2-1445 Add ingest monitoring dashboard.

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -14,6 +14,7 @@ locals {
   java_lambda_memory_size                 = 512
   python_runtime                          = "python3.11"
   python_lambda_memory_size               = 128
+  step_function_failure_log_group         = "step-function-failures"
 }
 resource "random_password" "preservica_password" {
   length = 20
@@ -258,7 +259,7 @@ module "failed_ingest_step_function_event_bridge_rule" {
   })
   name                = "${local.environment}-eventbridge-ingest-step-function-failure"
   api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
-  input_transformer = {
+  api_destination_input_transformer = {
     input_paths = {
       "name"   = "$.detail.name",
       "status" = "$.detail.status"
@@ -268,7 +269,21 @@ module "failed_ingest_step_function_event_bridge_rule" {
       slackMessage = ":alert-noflash-slow: Step function ${local.ingest_step_function_name} with name <name> has <status>"
     })
   }
+  log_group_destination_input_transformer = {
+    log_group_name = local.step_function_failure_log_group
+    input_paths = {
+      "name"      = "$.detail.name",
+      "status"    = "$.detail.status",
+      "startDate" = "$.detail.startDate"
+    }
+    input_template = templatefile("${path.module}/templates/eventbridge/cloudwatch_message_input_template.json.tpl", {
+      message = "Step function ${local.ingest_step_function_name} with name <name> has <status>"
+    })
+  }
+
 }
+
+
 
 module "dev_slack_message_eventbridge_rule" {
   source              = "git::https://github.com/nationalarchives/da-terraform-modules//eventbridge_api_destination_rule"
@@ -300,4 +315,18 @@ module "general_slack_message_eventbridge_rule" {
       slackMessage = "<slackMessage>"
     })
   }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "eventbridge_resource_policy" {
+  policy_document = templatefile("${path.module}/templates/logs/logs_resource_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id })
+  policy_name     = "TrustEventsToStoreLogEvents"
+}
+
+resource "aws_cloudwatch_dashboard" "ingest_dashboard" {
+  dashboard_body = templatefile("${path.module}/templates/logs/ingest_dashboard.json.tpl", {
+    account_id                      = data.aws_caller_identity.current.account_id,
+    environment                     = local.environment,
+    step_function_failure_log_group = local.step_function_failure_log_group
+  })
+  dashboard_name = "IngestDashboard"
 }

--- a/templates/eventbridge/cloudwatch_message_input_template.json.tpl
+++ b/templates/eventbridge/cloudwatch_message_input_template.json.tpl
@@ -1,0 +1,4 @@
+{
+  "timestamp" : <startDate>,
+  "message": "${message}"
+}

--- a/templates/logs/ingest_dashboard.json.tpl
+++ b/templates/logs/ingest_dashboard.json.tpl
@@ -1,0 +1,60 @@
+{
+  "widgets": [
+    {
+      "height": 6,
+      "width": 24,
+      "y": 0,
+      "x": 0,
+      "type": "log",
+      "properties": {
+        "query": "SOURCE '/aws/lambda/${environment}-ingest-parsed-court-document-event-handler' | SOURCE '/aws/lambda/${environment}-ingest-mapper' | SOURCE '/aws/lambda/${environment}-court-document-package-anonymiser' | SOURCE '/aws/lambda/${environment}-ingest-asset-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-folder-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-parent-folder-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-start-workflow' | SOURCE '/aws/lambda/${environment}-ingest-upsert-archive-folders' | SOURCE '/aws/lambda/${environment}-s3-copy' | fields @timestamp, message, error.message, log.level, @logStream\n| filter log.level == \"ERROR\"\n| sort @timestamp, batchRef desc\n| limit 20",
+        "region": "eu-west-2",
+        "stacked": false,
+        "title": "Errors",
+        "view": "table"
+      }
+    },
+    {
+      "height": 6,
+      "width": 24,
+      "y": 6,
+      "x": 0,
+      "type": "log",
+      "properties": {
+        "query": "SOURCE '/aws/lambda/${environment}-ingest-parsed-court-document-event-handler' | SOURCE '/aws/lambda/${environment}-ingest-mapper' | SOURCE '/aws/lambda/${environment}-ingest-folder-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-asset-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-parent-folder-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-start-workflow' | SOURCE '/aws/lambda/${environment}-ingest-upsert-archive-folders' | SOURCE '/aws/lambda/${environment}-s3-copy' | fields @timestamp, batchRef, fileReference, log.logger, message, @logStream\n| filter ispresent(batchRef)\n| sort @timestamp asc",
+        "region": "eu-west-2",
+        "stacked": false,
+        "title": "Lambda Logs",
+        "view": "table"
+      }
+    },
+    {
+      "height": 2,
+      "width": 18,
+      "y": 12,
+      "x": 0,
+      "type": "alarm",
+      "properties": {
+        "title": "SQS DLQ Alarms",
+        "alarms": [
+          "arn:aws:cloudwatch:eu-west-2:${account_id}:alarm:${environment}-ingest-parsed-court-document-event-handler-dlq-alarm",
+          "arn:aws:cloudwatch:eu-west-2:${account_id}:alarm:${environment}-court-document-package-anonymiser-dlq-alarm",
+          "arn:aws:cloudwatch:eu-west-2:${account_id}:alarm:${environment}-download-files-and-metadata-dlq-alarm"
+        ]
+      }
+    },
+    {
+      "height": 6,
+      "width": 24,
+      "y": 14,
+      "x": 0,
+      "type": "log",
+      "properties": {
+        "query": "SOURCE '/aws/events/${step_function_failure_log_group}' | fields @timestamp, @message, @logStream\n| sort @timestamp desc\n| limit 20",
+        "region": "eu-west-2",
+        "stacked": false,
+        "view": "table"
+      }
+    }
+  ]
+}

--- a/templates/logs/logs_resource_policy.json.tpl
+++ b/templates/logs/logs_resource_policy.json.tpl
@@ -1,0 +1,20 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TrustEventsToStoreLogEvent",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "delivery.logs.amazonaws.com",
+          "events.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:eu-west-2:${account_id}:log-group:/aws/events/*:*"
+    }
+  ]
+}


### PR DESCRIPTION
This adds an event target to the sfn failure eventbridge rule to log to
a cloudwatch log group and adds the permissions for eventbridge to do
that.

It also adds the dashboard json.
