### PR TITLE
Don't create the anonymiser lambda in staging and prod

### DIFF
--- a/anonymiser.tf
+++ b/anonymiser.tf
@@ -1,19 +1,21 @@
 locals {
   court_document_anonymiser_lambda_name = "${local.environment}-court-document-package-anonymiser"
   court_document_anonymiser_queue_name  = "${local.environment}-court-document-package-anonymiser"
+  court_document_anonymiser_count       = local.environment == "intg" ? 1 : 0
   tre_terraform_prod_config             = module.tre_config.terraform_config["prod"]
 }
 module "court_document_package_anonymiser_lambda" {
+  count           = local.court_document_anonymiser_count
   source          = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"
   function_name   = local.court_document_anonymiser_lambda_name
   handler         = "bootstrap"
   timeout_seconds = 30
   lambda_sqs_queue_mappings = [{
-    sqs_queue_arn = module.court_document_package_anonymiser_sqs.sqs_arn
+    sqs_queue_arn = "arn:aws:sqs:eu-west-2:${data.aws_caller_identity.current.account_id}:${local.court_document_anonymiser_queue_name}"
   }]
   policies = {
     "${local.court_document_anonymiser_lambda_name}-policy" = templatefile("./templates/iam_policy/anonymiser_lambda_policy.json.tpl", {
-      anonymiser_test_input_queue         = module.court_document_package_anonymiser_sqs.sqs_arn
+      anonymiser_test_input_queue         = module.court_document_package_anonymiser_sqs[count.index].sqs_arn
       ingest_court_document_handler_queue = module.ingest_parsed_court_document_event_handler_sqs.sqs_arn
       output_bucket_name                  = local.ingest_parsed_court_document_event_handler_test_bucket_name
       account_id                          = var.account_number
@@ -32,6 +34,7 @@ module "court_document_package_anonymiser_lambda" {
 }
 
 module "court_document_package_anonymiser_sqs" {
+  count      = local.court_document_anonymiser_count
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = local.court_document_anonymiser_queue_name
   sqs_policy = templatefile("./templates/sqs/sns_send_message_policy.json.tpl", {
@@ -45,8 +48,8 @@ module "court_document_package_anonymiser_sqs" {
 }
 
 resource "aws_sns_topic_subscription" "tre_topic_subscription" {
-  count                = local.environment == "intg" ? 1 : 0
-  endpoint             = module.court_document_package_anonymiser_sqs.sqs_arn
+  count                = local.court_document_anonymiser_count
+  endpoint             = module.court_document_package_anonymiser_sqs[count.index].sqs_arn
   protocol             = "sqs"
   topic_arn            = local.tre_terraform_prod_config["da_eventbus"]
   raw_message_delivery = true

--- a/common.tf
+++ b/common.tf
@@ -5,6 +5,8 @@ locals {
   ingest_staging_cache_bucket_name        = "${local.environment}-dr2-ingest-staging-cache"
   ingest_step_function_name               = "${local.environment_title}-ingest"
   additional_user_roles                   = local.environment != "prod" ? [data.aws_ssm_parameter.dev_admin_role.value] : []
+  anonymiser_roles                        = local.environment == "intg" ? [module.court_document_package_anonymiser_lambda[0].lambda_role_arn] : []
+  anonymiser_lambda_arns                  = local.environment == "intg" ? module.court_document_package_anonymiser_lambda.*.lambda_arn : []
   files_dynamo_table_name                 = "${local.environment}-dr2-files"
   files_table_global_secondary_index_name = "BatchParentPathIdx"
   dev_notifications_channel_id            = "C052LJASZ08"
@@ -97,9 +99,8 @@ module "dr2_kms_key" {
       module.e2e_tests_ecs_task_role.role_arn,
       module.copy_tna_to_preservica_role.role_arn,
       local.tre_prod_judgment_role,
-      module.s3_copy_lambda.lambda_role_arn,
-      module.court_document_package_anonymiser_lambda.lambda_role_arn
-    ], local.additional_user_roles)
+      module.s3_copy_lambda.lambda_role_arn
+    ], local.additional_user_roles, local.anonymiser_roles)
     ci_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.environment_title}TerraformRole"]
     service_details = [
       { service_name = "cloudwatch" },

--- a/deploy_roles.tf
+++ b/deploy_roles.tf
@@ -12,20 +12,22 @@ module "deploy_lambda_policy" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_policy"
   name   = "${local.environment_title}DPGithubActionsDeployLambdaPolicy"
   policy_string = templatefile("${path.module}/templates/iam_policy/deploy_lambda_policy.json.tpl", {
-    lambda_arns = jsonencode([
-      module.download_metadata_and_files_lambda.lambda_arn,
-      module.ip_lock_checker_lambda.lambda_arn,
-      module.ingest_parsed_court_document_event_handler_lambda.lambda_arn,
-      module.entity_event_generator_lambda.lambda_arn,
-      module.ingest_mapper_lambda.lambda_arn,
-      module.ingest_asset_opex_creator_lambda.lambda_arn,
-      module.ingest_folder_opex_creator_lambda.lambda_arn,
-      module.ingest_upsert_archive_folders_lambda.lambda_arn,
-      module.ingest_parent_folder_opex_creator_lambda.lambda_arn,
-      module.ingest_start_workflow_lambda.lambda_arn,
-      module.s3_copy_lambda.lambda_arn,
-      module.court_document_package_anonymiser_lambda.lambda_arn
-    ])
+    lambda_arns = jsonencode(flatten(
+      [
+        module.download_metadata_and_files_lambda.lambda_arn,
+        module.ip_lock_checker_lambda.lambda_arn,
+        module.ingest_parsed_court_document_event_handler_lambda.lambda_arn,
+        module.entity_event_generator_lambda.lambda_arn,
+        module.ingest_mapper_lambda.lambda_arn,
+        module.ingest_asset_opex_creator_lambda.lambda_arn,
+        module.ingest_folder_opex_creator_lambda.lambda_arn,
+        module.ingest_upsert_archive_folders_lambda.lambda_arn,
+        module.ingest_parent_folder_opex_creator_lambda.lambda_arn,
+        module.ingest_start_workflow_lambda.lambda_arn,
+        module.s3_copy_lambda.lambda_arn,
+        local.anonymiser_lambda_arns
+      ]
+    ))
     bucket_name = "mgmt-dp-code-deploy"
   })
 }

--- a/download_metadata_and_files_lambda.tf
+++ b/download_metadata_and_files_lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  disaster_recovery_bucket_name           = "${local.environment}-disaster-recovery"
+  disaster_recovery_bucket_name           = "${local.environment}-dr2-disaster-recovery"
   download_files_and_metadata_lambda_name = "${local.environment}-download-files-and-metadata"
   download_metadata_and_files_queue_name  = "${local.environment}-download-files-and-metadata"
 }

--- a/templates/logs/ingest_dashboard.json.tpl
+++ b/templates/logs/ingest_dashboard.json.tpl
@@ -37,9 +37,7 @@
       "properties": {
         "title": "SQS DLQ Alarms",
         "alarms": [
-          "arn:aws:cloudwatch:eu-west-2:${account_id}:alarm:${environment}-ingest-parsed-court-document-event-handler-dlq-alarm",
-          "arn:aws:cloudwatch:eu-west-2:${account_id}:alarm:${environment}-court-document-package-anonymiser-dlq-alarm",
-          "arn:aws:cloudwatch:eu-west-2:${account_id}:alarm:${environment}-download-files-and-metadata-dlq-alarm"
+          "arn:aws:cloudwatch:eu-west-2:${account_id}:alarm:${environment}-ingest-parsed-court-document-event-handler-dlq-alarm"
         ]
       }
     },

--- a/templates/logs/ingest_dashboard.json.tpl
+++ b/templates/logs/ingest_dashboard.json.tpl
@@ -7,7 +7,7 @@
       "x": 0,
       "type": "log",
       "properties": {
-        "query": "SOURCE '/aws/lambda/${environment}-ingest-parsed-court-document-event-handler' | SOURCE '/aws/lambda/${environment}-ingest-mapper' | SOURCE '/aws/lambda/${environment}-court-document-package-anonymiser' | SOURCE '/aws/lambda/${environment}-ingest-asset-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-folder-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-parent-folder-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-start-workflow' | SOURCE '/aws/lambda/${environment}-ingest-upsert-archive-folders' | SOURCE '/aws/lambda/${environment}-s3-copy' | fields @timestamp, message, error.message, log.level, @logStream\n| filter log.level == \"ERROR\"\n| sort @timestamp, batchRef desc\n| limit 20",
+        "query": "SOURCE '/aws/lambda/${environment}-ingest-parsed-court-document-event-handler' | SOURCE '/aws/lambda/${environment}-ingest-mapper' | SOURCE '/aws/lambda/${environment}-ingest-asset-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-folder-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-parent-folder-opex-creator' | SOURCE '/aws/lambda/${environment}-ingest-start-workflow' | SOURCE '/aws/lambda/${environment}-ingest-upsert-archive-folders' | SOURCE '/aws/lambda/${environment}-s3-copy' | fields @timestamp, message, error.message, log.level, @logStream\n| filter log.level == \"ERROR\"\n| sort @timestamp, batchRef desc\n| limit 20",
         "region": "eu-west-2",
         "stacked": false,
         "title": "Errors",


### PR DESCRIPTION
Also, rename the disaster recovery bucket.
Also, remove the anonymiser queue and download files queue from the dashboard. The anonymiser queue isn't in staging or prod and the download files queue isn't even used so they don't need to be here.