### PR TITLE
Add RedriveExecution permissions.

### DIFF
--- a/templates/iam_policy/ingest_step_function_policy.json.tpl
+++ b/templates/iam_policy/ingest_step_function_policy.json.tpl
@@ -4,6 +4,7 @@
       "Sid": "sfnPolicy",
       "Effect": "Allow",
       "Action": [
+        "states:RedriveExecution",
         "lambda:InvokeFunction",
         "states:StartExecution",
         "s3:ListBucket"
@@ -17,6 +18,8 @@
         "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_start_workflow_lambda_name}",
         "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_s3_copy_lambda_name}",
         "arn:aws:states:eu-west-2:${account_id}:stateMachine:${ingest_sfn_name}",
+        "arn:aws:states:eu-west-2:${account_id}:execution:${ingest_sfn_name}/StagingCacheS3ObjectKeys:*",
+        "arn:aws:states:eu-west-2:${account_id}:execution:${ingest_sfn_name}:*",
         "arn:aws:s3:::${ingest_staging_cache_bucket_name}"
       ]
     }


### PR DESCRIPTION
These are needed to run the new redrive feature.

We need two arns because the first one is the distributed map which in
effect creates a new step function execution with the name
"Intg-ingest/StagingCacheS3ObjectKeys"

I've tested this on integration and it lets me re-run the step
functions.
