### PR TITLE
DR2-1484 Guard duty alerts

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -340,10 +340,10 @@ module "guard_duty_findings_eventbridge_rule" {
   api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
   api_destination_input_transformer = {
     input_paths = {
-      "account": "$.account",
-      "id": "$.detail.id",
-      "region": "$.region",
-      "title": "$.detail.title"
+      "account" : "$.account",
+      "id" : "$.detail.id",
+      "region" : "$.region",
+      "title" : "$.detail.title"
     }
     input_template = templatefile("${path.module}/templates/eventbridge/guard_duty_slack_message.json.tpl", {})
   }

--- a/common.tf
+++ b/common.tf
@@ -331,7 +331,23 @@ module "failed_ingest_step_function_event_bridge_rule" {
 
 }
 
-
+module "guard_duty_findings_eventbridge_rule" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//eventbridge_api_destination_rule"
+  event_pattern = templatefile("${path.module}/templates/eventbridge/source_detail_type_event_pattern.json.tpl", {
+    source = "aws.guardduty", detail_type = "GuardDuty Finding"
+  })
+  name                = "${local.environment}-guard-duty-notify"
+  api_destination_arn = module.eventbridge_alarm_notifications_destination.api_destination_arn
+  api_destination_input_transformer = {
+    input_paths = {
+      "account": "$.account",
+      "id": "$.detail.id",
+      "region": "$.region",
+      "title": "$.detail.title"
+    }
+    input_template = templatefile("${path.module}/templates/eventbridge/guard_duty_slack_message.json.tpl", {})
+  }
+}
 
 module "dev_slack_message_eventbridge_rule" {
   source              = "git::https://github.com/nationalarchives/da-terraform-modules//eventbridge_api_destination_rule"

--- a/templates/eventbridge/guard_duty_slack_message.json.tpl
+++ b/templates/eventbridge/guard_duty_slack_message.json.tpl
@@ -1,0 +1,5 @@
+{
+  "channel" : "C06EDJPF0VB",
+  "text": ":alert-noflash-slow: GuardDuty finding for account <account>\n<title>\nView finding <https://eu-west-2.console.aws.amazon.com/guardduty/home?region=<region>#/findings?macros=current&fId=<id>|in the console>"
+}
+

--- a/templates/eventbridge/guard_duty_slack_message.json.tpl
+++ b/templates/eventbridge/guard_duty_slack_message.json.tpl
@@ -1,5 +1,5 @@
 {
   "channel" : "C06EDJPF0VB",
-  "text": ":alert-noflash-slow: GuardDuty finding for account <account>\n<title>\nView finding <https://eu-west-2.console.aws.amazon.com/guardduty/home?region=<region>#/findings?macros=current&fId=<id>|in the console>"
+  "text": ":alert-noflash-slow: GuardDuty finding for account <account>\n<title>\nView finding <https://<region>.console.aws.amazon.com/guardduty/home?region=<region>#/findings?macros=current&fId=<id>|in the console>"
 }
 

--- a/templates/eventbridge/source_detail_type_event_pattern.json.tpl
+++ b/templates/eventbridge/source_detail_type_event_pattern.json.tpl
@@ -1,0 +1,4 @@
+{
+  "source": ["${source}"],
+  "detail-type": ["${detail_type}"]
+}


### PR DESCRIPTION
Add Guard Duty finding alerts.

I can't seem to use the existing slack template as terraform gets very
upset when I try to use newlines inside a json template.

I've also hard coded the prod dev channel in the slack template so we
don't lose any findings in the other noise.
