### PR TITLE
DR2-1584 Create entity queue and DR user

### DIFF
--- a/disaster_recovery.tf
+++ b/disaster_recovery.tf
@@ -1,3 +1,6 @@
+locals {
+  disaster_recovery_name = "dr2-${local.environment}-disaster-recovery"
+}
 module "disaster_recovery_bucket" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
   bucket_name = local.disaster_recovery_bucket_name
@@ -9,4 +12,31 @@ module "disaster_recovery_bucket" {
     bucket_name      = local.disaster_recovery_bucket_name
   })
   kms_key_arn = module.dr2_kms_key.kms_key_arn
+}
+
+resource "aws_iam_user" "disaster_recovery_user" {
+  name = local.disaster_recovery_name
+}
+
+resource "aws_iam_access_key" "disaster_recovery_user_access_key" {
+  user = local.disaster_recovery_name
+}
+
+resource "aws_iam_user_group_membership" "disaster_recovery_group_membership" {
+  groups = [aws_iam_group.disaster_recovery_group.name]
+  user   = aws_iam_user.disaster_recovery_user.name
+}
+
+resource "aws_iam_group" "disaster_recovery_group" {
+  name = local.disaster_recovery_name
+}
+
+resource "aws_iam_group_policy" "disaster_recovery_group_policy" {
+  group = aws_iam_group.disaster_recovery_group.name
+  name  = "dr2-${local.environment}-disaster-recovery-policy"
+  policy = templatefile("${path.module}/templates/iam_policy/disaster_recovery_policy.json.tpl", {
+    account_id                 = data.aws_caller_identity.current.account_id
+    secrets_manager_secret_arn = aws_secretsmanager_secret.preservica_secret.arn
+    entity_event_queue         = module.entity_event_generator_queue.sqs_arn
+  })
 }

--- a/templates/iam_policy/disaster_recovery_policy.json.tpl
+++ b/templates/iam_policy/disaster_recovery_policy.json.tpl
@@ -18,6 +18,14 @@
     },
     {
       "Action": [
+        "cloudwatch:PutMetricData"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "putMetrics"
+    },
+    {
+      "Action": [
         "logs:PutLogEvents",
         "logs:PutRetentionPolicy",
         "logs:DescribeLogStreams",

--- a/templates/iam_policy/disaster_recovery_policy.json.tpl
+++ b/templates/iam_policy/disaster_recovery_policy.json.tpl
@@ -1,0 +1,38 @@
+{
+  "Statement": [
+    {
+      "Action": "secretsmanager:GetSecretValue",
+      "Effect": "Allow",
+      "Resource": "${secrets_manager_secret_arn}",
+      "Sid": "readSecretsManager"
+    },
+    {
+      "Action": [
+        "sqs:ReceiveMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:DeleteMessage"
+      ],
+      "Effect": "Allow",
+      "Resource": "${entity_event_queue}",
+      "Sid": "readSqs"
+    },
+    {
+      "Action": [
+        "logs:PutLogEvents",
+        "logs:PutRetentionPolicy",
+        "logs:DescribeLogStreams",
+        "logs:DescribeLogGroups",
+        "logs:CreateLogStream",
+        "logs:CreateLogGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/disaster-recovery:*:*",
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/disaster-recovery:*",
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/disaster-recovery"
+      ],
+      "Sid": "writeLogs"
+    }
+  ],
+  "Version": "2012-10-17"
+}


### PR DESCRIPTION
This is the user which will be used by the disaster recovery service.

We also didn't have a terraformed entity event queue listening to the
topic so I've added this in.
