### PR TITLE
DR2-1591 Add new queue to topic subscription.

### DIFF
--- a/anonymiser.tf
+++ b/anonymiser.tf
@@ -94,7 +94,7 @@ module "dr2_court_document_package_anonymiser_sqs" {
 
 resource "aws_sns_topic_subscription" "tre_topic_subscription" {
   count                = local.court_document_anonymiser_count
-  endpoint             = module.court_document_package_anonymiser_sqs[count.index].sqs_arn
+  endpoint             = module.dr2_court_document_package_anonymiser_sqs[count.index].sqs_arn
   protocol             = "sqs"
   topic_arn            = local.tre_terraform_prod_config["da_eventbus"]
   raw_message_delivery = true

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -148,3 +148,14 @@ resource "aws_sns_topic_subscription" "tre_topic_court_document_subscription" {
   filter_policy_scope  = "MessageBody"
   filter_policy        = templatefile("${path.module}/templates/sns/tre_live_stream_filter_policy.json.tpl", {})
 }
+
+resource "aws_sns_topic_subscription" "dr2_tre_topic_court_document_subscription" {
+  # Only do this for prod now. We might do staging if that ends up pointing to prod Preservica
+  count                = local.environment == "prod" ? 1 : 0
+  endpoint             = module.dr2_ingest_parsed_court_document_event_handler_sqs.sqs_arn
+  protocol             = "sqs"
+  topic_arn            = local.tre_prod_event_bus
+  raw_message_delivery = true
+  filter_policy_scope  = "MessageBody"
+  filter_policy        = templatefile("${path.module}/templates/sns/tre_live_stream_filter_policy.json.tpl", {})
+}


### PR DESCRIPTION
For the prod queue linked to the TRE topic, I've added a num
subscription to the new queue. Before I deploy this, I'll disable the
trigger for the court document lambda. Then if any messages come through
while this subscription is being added, we won't lose them.

If I just change the subscription, there'll be a tiny window where
there'll be no subscription and sod's law says we'll get a message then
so this is safer.

For the anonymiser queue, we don't care if we lose a message so this is
just being replaced.
