### PR TITLE
Fixes for things I missed the first time

### DIFF
--- a/anonymiser.tf
+++ b/anonymiser.tf
@@ -48,7 +48,7 @@ module "dr2_court_document_package_anonymiser_lambda" {
     "${local.court_document_anonymiser_lambda_name}-policy" = templatefile("./templates/iam_policy/anonymiser_lambda_policy.json.tpl", {
       anonymiser_test_input_queue         = module.dr2_court_document_package_anonymiser_sqs[count.index].sqs_arn
       ingest_court_document_handler_queue = module.dr2_ingest_parsed_court_document_event_handler_sqs.sqs_arn
-      output_bucket_name                  = local.ingest_parsed_court_document_event_handler_test_bucket_name_old
+      output_bucket_name                  = local.ingest_parsed_court_document_event_handler_test_bucket_name
       account_id                          = var.account_number
       lambda_name                         = local.court_document_anonymiser_lambda_name
       tre_bucket_arn                      = local.tre_terraform_prod_config["s3_court_document_pack_out_arn"]
@@ -58,7 +58,7 @@ module "dr2_court_document_package_anonymiser_lambda" {
   memory_size = 128
   runtime     = "provided.al2023"
   plaintext_env_vars = {
-    OUTPUT_BUCKET = local.ingest_parsed_court_document_event_handler_test_bucket_name_old
+    OUTPUT_BUCKET = local.ingest_parsed_court_document_event_handler_test_bucket_name
     OUTPUT_QUEUE  = module.dr2_ingest_parsed_court_document_event_handler_sqs.sqs_queue_url
   }
   tags = {}

--- a/common.tf
+++ b/common.tf
@@ -6,7 +6,7 @@ locals {
   ingest_step_function_name_old                 = "${local.environment_title}-ingest"
   ingest_step_function_name                     = "${local.environment}-dr2-ingest"
   additional_user_roles                         = local.environment != "prod" ? [data.aws_ssm_parameter.dev_admin_role.value] : []
-  anonymiser_roles                              = local.environment == "intg" ? [module.court_document_package_anonymiser_lambda[0].lambda_role_arn] : []
+  anonymiser_roles                              = local.environment == "intg" ? [module.court_document_package_anonymiser_lambda[0].lambda_role_arn, module.dr2_court_document_package_anonymiser_lambda[0].lambda_role_arn] : []
   anonymiser_lambda_arns                        = local.environment == "intg" ? flatten([module.court_document_package_anonymiser_lambda.*.lambda_arn, module.dr2_court_document_package_anonymiser_lambda.*.lambda_arn]) : []
   files_dynamo_table_name                       = "${local.environment}-dr2-files"
   ingest_lock_dynamo_table_name                 = "${local.environment}-dr2-ingest-lock"

--- a/common.tf
+++ b/common.tf
@@ -228,7 +228,7 @@ module "dr2_ingest_step_function" {
   })
   step_function_name = local.ingest_step_function_name
   step_function_role_policy_attachments = {
-    step_function_policy = module.ingest_step_function_policy.policy_arn
+    step_function_policy = module.dr2_ingest_step_function_policy.policy_arn
   }
 }
 
@@ -285,7 +285,7 @@ resource "aws_datasync_task" "dr2_copy_tna_to_preservica" {
 
 module "ingest_step_function_policy" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_policy"
-  name   = "${local.environment_title}-dr2-ingest-step-function-policy"
+  name   = "${local.environment_title}-ingest-step-function-policy"
   policy_string = templatefile("${path.module}/templates/iam_policy/ingest_step_function_policy.json.tpl", {
     account_id                                    = var.account_number
     ingest_mapper_lambda_name                     = local.ingest_mapper_lambda_name_old
@@ -299,6 +299,26 @@ module "ingest_step_function_policy" {
     ingest_asset_reconciler_lambda_name           = local.ingest_asset_reconciler_lambda_name_old
     ingest_staging_cache_bucket_name              = local.ingest_staging_cache_bucket_name
     ingest_sfn_name                               = local.ingest_step_function_name_old
+    tna_to_preservica_role_arn                    = local.tna_to_preservica_role_arn
+  })
+}
+
+module "dr2_ingest_step_function_policy" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_policy"
+  name   = "${local.environment}-dr2-ingest-step-function-policy"
+  policy_string = templatefile("${path.module}/templates/iam_policy/ingest_step_function_policy.json.tpl", {
+    account_id                                    = var.account_number
+    ingest_mapper_lambda_name                     = local.ingest_mapper_lambda_name
+    ingest_upsert_archive_folders_lambda_name     = local.ingest_upsert_archive_folders_lambda_name
+    ingest_check_preservica_for_existing_io       = local.ingest_check_preservica_for_existing_io_lambda_name
+    ingest_asset_opex_creator_lambda_name         = local.ingest_asset_opex_creator_lambda_name
+    ingest_folder_opex_creator_lambda_name        = local.ingest_folder_opex_creator_lambda_name
+    ingest_parent_folder_opex_creator_lambda_name = local.ingest_parent_folder_opex_creator_lambda_name
+    ingest_start_workflow_lambda_name             = local.ingest_start_workflow_lambda_name
+    ingest_workflow_monitor_lambda_name           = local.ingest_workflow_monitor_lambda_name
+    ingest_asset_reconciler_lambda_name           = local.ingest_asset_reconciler_lambda_name
+    ingest_staging_cache_bucket_name              = local.ingest_staging_cache_bucket_name
+    ingest_sfn_name                               = local.ingest_step_function_name
     tna_to_preservica_role_arn                    = local.tna_to_preservica_role_arn
   })
 }

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -26,7 +26,7 @@ module "dr2_ingest_parsed_court_document_event_handler_test_input_bucket" {
   source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
   bucket_name = local.ingest_parsed_court_document_event_handler_test_bucket_name
   bucket_policy = templatefile("./templates/s3/lambda_access_bucket_policy.json.tpl", {
-    lambda_role_arns = jsonencode([module.ingest_parsed_court_document_event_handler_lambda.lambda_role_arn, "arn:aws:iam::${module.tre_config.account_numbers["prod"]}:role/prod-tre-editorial-judgment-out-copier"]),
+    lambda_role_arns = jsonencode([module.dr2_ingest_parsed_court_document_event_handler_lambda.lambda_role_arn, "arn:aws:iam::${module.tre_config.account_numbers["prod"]}:role/prod-tre-editorial-judgment-out-copier"]),
     bucket_name      = local.ingest_parsed_court_document_event_handler_test_bucket_name
   })
   kms_key_arn = module.dr2_kms_key.kms_key_arn
@@ -121,7 +121,7 @@ module "dr2_ingest_parsed_court_document_event_handler_lambda" {
       bucket_name                                          = local.ingest_raw_cache_bucket_name
       account_id                                           = var.account_number
       lambda_name                                          = local.ingest_parsed_court_document_event_handler_lambda_name
-      step_function_arn                                    = module.ingest_step_function.step_function_arn
+      step_function_arn                                    = module.dr2_ingest_step_function.step_function_arn
       tre_kms_arn                                          = module.tre_config.terraform_config["prod_s3_court_document_pack_out_kms_arn"]
       tre_bucket_arn                                       = local.tre_terraform_prod_config["s3_court_document_pack_out_arn"]
     })
@@ -130,7 +130,7 @@ module "dr2_ingest_parsed_court_document_event_handler_lambda" {
   runtime     = local.java_runtime
   plaintext_env_vars = {
     OUTPUT_BUCKET = local.ingest_raw_cache_bucket_name
-    SFN_ARN       = module.ingest_step_function.step_function_arn
+    SFN_ARN       = module.dr2_ingest_step_function.step_function_arn
   }
   tags = {
     Name      = local.ingest_parsed_court_document_event_handler_lambda_name


### PR DESCRIPTION
The new anonymiser lambda was writing to the wrong bucket and sending a
message with the old bucket.

The KMS key didn't have the new anonymiser lambda in it's list of
allowed decrypt roles.

The new parsed document handler was starting the old step function.
