### PR TITLE
DR2-1639 Update Github actions role trust policy.

### DIFF
--- a/e2e_tests.tf
+++ b/e2e_tests.tf
@@ -1,7 +1,13 @@
 module "run_e2e_tests_role" {
-  source             = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
-  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dr2-*" })
-  name               = "${local.environment}-dr2-run-e2e-tests-role"
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", {
+    account_id = data.aws_caller_identity.current.account_id,
+    repo_filters = jsonencode([
+      "repo:nationalarchives/dr2-e2e-tests:environment:${local.environment}",
+      "repo:nationalarchives/dr2-e2e-tests:ref:refs/heads/main"
+    ])
+  })
+  name = "${local.environment}-dr2-run-e2e-tests-role"
   policy_attachments = {
     run_e2e_tests_policy = module.run_e2e_tests_policy.policy_arn
   }

--- a/templates/iam_role/github_assume_role.json.tpl
+++ b/templates/iam_role/github_assume_role.json.tpl
@@ -12,7 +12,7 @@
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
         },
         "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:nationalarchives/${repo_filter}"
+          "token.actions.githubusercontent.com:sub": ${repo_filters}
         }
       }
     }


### PR DESCRIPTION
These should be limited only to the environments and repositories that
they need
