### PR TITLE
Small terraform fixes

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -137,7 +137,6 @@ module "dr2_kms_key" {
       { service_name = "sns", service_source_account = module.tre_config.account_numbers["prod"] },
       { service_name = "sns" },
     ]
-    service_names = ["cloudwatch", "sns"]
   }
 }
 
@@ -149,8 +148,13 @@ module "dr2_developer_key" {
       data.aws_ssm_parameter.dev_admin_role.value,
       module.dr2_preservica_config_lambda.lambda_role_arn
     ]
-    ci_roles      = [local.terraform_role_arn]
-    service_names = ["s3", "sns", "logs.eu-west-2", "cloudwatch"]
+    ci_roles = [local.terraform_role_arn]
+    service_details = [
+      { service_name = "s3" },
+      { service_name = "sns" },
+      { service_name = "logs.eu-west-2" },
+      { service_name = "cloudwatch" }
+    ]
   }
 }
 

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -26,7 +26,7 @@ module "dr2_preservica_config_sns" {
   tags = {
     Name = "Preservica Config SNS"
   }
-  topic_name  = "${local.environment}-preservica-config"
+  topic_name  = local.preservica_config_sqs_name
   kms_key_arn = module.dr2_developer_key.kms_key_arn
   sqs_subscriptions = {
     preservica_config_queue = module.dr2_preservica_config_queue.sqs_arn

--- a/templates/s3/lambda_access_bucket_policy.json.tpl
+++ b/templates/s3/lambda_access_bucket_policy.json.tpl
@@ -15,21 +15,6 @@
         "arn:aws:s3:::${bucket_name}",
         "arn:aws:s3:::${bucket_name}/*"
       ]
-    },
-    {
-      "Sid": "AllowSSLRequestsOnly",
-      "Effect": "Deny",
-      "Principal": "*",
-      "Action": "s3:*",
-      "Resource": [
-        "arn:aws:s3:::${bucket_name}",
-        "arn:aws:s3:::${bucket_name}/*"
-      ],
-      "Condition": {
-        "Bool": {
-          "aws:SecureTransport": "false"
-        }
-      }
     }
   ]
 }

--- a/templates/s3/preservica_config_bucket_policy.json.tpl
+++ b/templates/s3/preservica_config_bucket_policy.json.tpl
@@ -10,21 +10,6 @@
         "s3:GetObject"
       ],
       "Resource": "arn:aws:s3:::${bucket_name}/*"
-    },
-    {
-      "Sid": "AllowSSLRequestsOnly",
-      "Effect": "Deny",
-      "Principal": "*",
-      "Action": "s3:*",
-      "Resource": [
-        "arn:aws:s3:::${bucket_name}",
-        "arn:aws:s3:::${bucket_name}/*"
-      ],
-      "Condition": {
-        "Bool": {
-          "aws:SecureTransport": "false"
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
* The dev kms key was using the old variable and so didn't have
  permissions for s3/sns etc.
* The newest da-terraform-modules adds the SSL only block for buckets so
  we don't need it here.
* The preservica config SNS topic had the wrong name and a mismatch
  between the resource in its policy and its name.
