### PR TITLE
DR2-1728 Add ttl column to the files table.

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -291,6 +291,7 @@ module "files_table" {
   table_name                     = local.files_dynamo_table_name
   server_side_encryption_enabled = true
   kms_key_arn                    = module.dr2_kms_key.kms_key_arn
+  ttl_attribute_name             = "ttl"
   additional_attributes = [
     { name = "batchId", type = "S" },
     { name = "parentPath", type = "S" },


### PR DESCRIPTION
This is a column for ttl so it's called ttl. There is no need to make
this any longer.

This will need deploying manually because the call needs KMS decrypt
permissions which terraform doesn't and shouldn't have.

The tests won't pass until https://github.com/nationalarchives/da-terraform-modules/pull/55 is merged but it's ready for review.
