### PR TITLE
Fix alert for e2e tests

### DIFF
--- a/templates/task_definitions/e2e_tests.json.tpl
+++ b/templates/task_definitions/e2e_tests.json.tpl
@@ -34,6 +34,7 @@
         "readOnly": false
       }
     ],
+    "readonlyRootFilesystem": true,
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
It was complaining about this not being set.

I think it will still work because we have bind mounts into the
container with readonly false so we can write files in certain
directories (I think)

If it doesn't work, we're not using them at the moment anyyway.
