### PR TITLE
DR2-1772 Secrets rotation and notifications.

### DIFF
--- a/templates/eventbridge/secrets_manager_rotation.json.tpl
+++ b/templates/eventbridge/secrets_manager_rotation.json.tpl
@@ -1,0 +1,11 @@
+{
+  "source": ["aws.secretsmanager"],
+  "$or": [
+    { "detail-type": ["AWS API Call via CloudTrail"] },
+    { "detail-type": ["AWS Service Event via CloudTrail"] }
+  ],
+  "detail": {
+    "eventSource": ["secretsmanager.amazonaws.com"],
+    "eventName": ["${rotation_event}"]
+  }
+}


### PR DESCRIPTION
We get one for RotationFailed and RotationSucceeded.

Because of the way the transformers work I've not included the error
message as it makes the terraform messy. This is find because Slack is
not a debugging tool.
