### PR TITLE
DR2-1755 Log external notifications

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -354,7 +354,8 @@ module "cloudwatch_alarm_event_bridge_rule" {
       module.dr2_ingest_parsed_court_document_event_handler_sqs.dlq_cloudwatch_alarm_arn,
       module.dr2_preservica_config_queue.dlq_cloudwatch_alarm_arn,
       module.dr2_database_builder_queue.dlq_cloudwatch_alarm_arn,
-      module.dr2_custodial_copy_queue.dlq_cloudwatch_alarm_arn
+      module.dr2_custodial_copy_queue.dlq_cloudwatch_alarm_arn,
+      module.dr2_external_notifications_queue.dlq_cloudwatch_alarm_arn
     ])),
     state_value = each.value
   })

--- a/external_notifications_log.tf
+++ b/external_notifications_log.tf
@@ -1,0 +1,53 @@
+locals {
+  external_notifications_queue_name     = "${local.environment}-external-notifications"
+  external_notifications_pipe_name      = "${local.environment}-external-notifications"
+  external_notifications_log_group_name = "/${local.environment}-external-notifications"
+}
+resource "aws_cloudwatch_log_group" "external_notification_log_group" {
+  name = local.external_notifications_log_group_name
+}
+
+module "dr2_external_notifications_pipes_role" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/service_source_account_only.json.tpl", {
+    account_id = data.aws_caller_identity.current.account_id,
+    service    = "pipes"
+  })
+  name = "${local.environment}-dr2-log-external-notifications"
+  policy_attachments = {
+    external_notifications_log = module.dr2_external_notifications_pipes_policy.policy_arn
+  }
+  tags = {}
+}
+
+module "dr2_external_notifications_queue" {
+  source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
+  queue_name = local.external_notifications_queue_name
+  sqs_policy = templatefile("./templates/sqs/sns_send_message_policy.json.tpl", {
+    account_id = var.account_number,
+    queue_name = local.external_notifications_queue_name
+    topic_arn  = module.dr2_notifications_sns.sns_arn
+  })
+  encryption_type = "sse"
+}
+
+module "dr2_external_notifications_pipes_policy" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_policy"
+  name   = "${local.environment}-dr2-log-external-notifications-policy"
+  policy_string = templatefile("${path.module}/templates/iam_policy/external_notification_log_pipe_policy.json.tpl", {
+    queue_arn      = module.dr2_external_notifications_queue.sqs_arn
+    account_id     = data.aws_caller_identity.current.account_id
+    log_group_name = local.external_notifications_log_group_name
+  })
+}
+
+resource "aws_pipes_pipe" "dr2_external_notifications_log_pipe" {
+  depends_on = [module.dr2_external_notifications_pipes_policy.policy_arn]
+  name       = local.external_notifications_pipe_name
+  role_arn   = module.dr2_external_notifications_pipes_role.role_arn
+  source     = module.dr2_external_notifications_queue.sqs_arn
+  target     = aws_cloudwatch_log_group.external_notification_log_group.arn
+  target_parameters {
+    input_template = templatefile("${path.module}/templates/pipes/sqs_to_cloudwatch_target_transformer.json.tpl", {})
+  }
+}

--- a/sns_notifications.tf
+++ b/sns_notifications.tf
@@ -12,4 +12,7 @@ module "dr2_notifications_sns" {
     Name = local.notifications_topic_name
   }
   topic_name = local.notifications_topic_name
+  sqs_subscriptions = {
+    log_external_notifications_queue = module.dr2_external_notifications_queue.sqs_arn
+  }
 }

--- a/templates/iam_policy/external_notification_log_pipe_policy.json.tpl
+++ b/templates/iam_policy/external_notification_log_pipe_policy.json.tpl
@@ -1,0 +1,28 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "sqs:ReceiveMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:DeleteMessage"
+      ],
+      "Effect": "Allow",
+      "Resource": "${queue_arn}",
+      "Sid": "readSqs"
+    },
+    {
+      "Action": [
+        "logs:PutLogEvents",
+        "logs:CreateLogStream",
+        "logs:CreateLogGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:${log_group_name}:*:*",
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:${log_group_name}:*"
+      ],
+      "Sid": "readWriteLogs"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/templates/iam_role/service_source_account_only.json.tpl
+++ b/templates/iam_role/service_source_account_only.json.tpl
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "${service}.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "${account_id}"
+        }
+      }
+    }
+  ]
+}

--- a/templates/pipes/sqs_to_cloudwatch_target_transformer.json.tpl
+++ b/templates/pipes/sqs_to_cloudwatch_target_transformer.json.tpl
@@ -1,4 +1,5 @@
 {
   "body": <$.body>,
-  "timestamp": <$.attributes.SentTimestamp>
+  "timestamp": <$.attributes.SentTimestamp>,
+  "topicArn": "${topic_arn}"
 }

--- a/templates/pipes/sqs_to_cloudwatch_target_transformer.json.tpl
+++ b/templates/pipes/sqs_to_cloudwatch_target_transformer.json.tpl
@@ -1,0 +1,4 @@
+{
+  "body": <$.body>,
+  "timestamp": <$.attributes.SentTimestamp>
+}


### PR DESCRIPTION
Anything going to the notifications topic will go
SNS -> SQS -> Eventbridge pipe -> Cloudwatch.

There is an input transformer configured so we don't get all the output
from the SQS message.

Given an SNS message:

```json
{
  "id": 1,
  "message": "Another test message"
}

```

You will end up with this in Cloudwatch:
```json
{
    "body": {
        "id": 1,
        "message": "Another test message"
    },
    "timestamp": "1720607411035"
}
```
