### PR TITLE
DR2-1718 Remove encryption from court document handler queue.

### DIFF
--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -48,7 +48,6 @@ module "dr2_ingest_parsed_court_document_event_handler_sqs" {
   })
   redrive_maximum_receives = 5
   visibility_timeout       = 180
-  kms_key_id               = module.dr2_kms_key.kms_key_arn
 }
 
 module "dr2_ingest_parsed_court_document_event_handler_lambda" {


### PR DESCRIPTION
This also removes it from the dlq.
