### PR TITLE
DR2-1768-Enable-deletion-protection-on-dr2-ingest-files

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -304,6 +304,7 @@ module "files_table" {
   ttl_attribute_name             = "ttl"
   stream_enabled                 = true
   stream_view_type               = "NEW_IMAGE"
+  deletion_protection_enabled    = true
   additional_attributes = [
     { name = "batchId", type = "S" },
     { name = "parentPath", type = "S" }


### PR DESCRIPTION
Simple one line change to enable delete protection