### PR TITLE
Remove notifications publish.

### DIFF
--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -461,31 +461,10 @@
               {
                 "Variable": "$.wasReconciled",
                 "BooleanEquals": true,
-                "Next": "Publish reconciliation update to dr2-notifications"
+                "Next": "Update ingested_PS attribute in Files table"
               }
             ],
             "Default": "Throw Reconciler job error"
-          },
-          "Publish reconciliation update to dr2-notifications": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::sns:publish",
-            "Parameters": {
-              "Message": {
-                "properties": {
-                  "messageId": "$.reconciliationSnsMessage.properties.messageId",
-                  "parentMessageId": "$.reconciliationSnsMessage.properties.parentMessageId",
-                  "timestamp": "$.reconciliationSnsMessage.properties.timestamp",
-                  "type": "preserve.digital.asset.ingest.update"
-                },
-                "parameters": {
-                  "assetName": "$.reconciliationSnsMessage.parameters.assetName",
-                  "status": "Asset has been ingested to the Preservation system."
-                }
-              },
-              "TopicArn": "arn:aws:sns:eu-west-2:${account_id}:${notifications_topic_name}"
-            },
-            "ResultPath": null,
-            "Next": "Update ingested_PS attribute in Files table"
           },
           "Update ingested_PS attribute in Files table": {
             "Type": "Task",


### PR DESCRIPTION
This step is now being done by the files change handler. Or it should
be, I'm not convinced it's working but it's harder to debug with this
sending as well and we won't need this if the files change handler
works properly so it can be removed.
