### PR TITLE
Add permissions for TDR KMS.

### DIFF
--- a/copy_files_from_tdr.tf
+++ b/copy_files_from_tdr.tf
@@ -20,6 +20,7 @@ module "dr2_copy_files_from_tdr_lambda" {
       aggregator_queue_arn          = local.tdr_aggregator_queue_arn
       account_id                    = data.aws_caller_identity.current.account_id
       lambda_name                   = local.copy_files_from_tdr_name
+      tdr_export_kms_arn            = module.tdr_config.terraform_config["${local.environment}_s3_export_bucket_kms_key_arn"]
     })
   }
   memory_size = local.python_lambda_memory_size

--- a/templates/iam_policy/copy_files_from_tdr_policy.json.tpl
+++ b/templates/iam_policy/copy_files_from_tdr_policy.json.tpl
@@ -2,6 +2,14 @@
   "Statement": [
     {
       "Action": [
+        "kms:Decrypt"
+      ],
+      "Effect": "Allow",
+      "Resource": "${tdr_export_kms_arn}",
+      "Sid": "DecryptWithTDRKey"
+    },
+    {
+      "Action": [
         "sqs:ReceiveMessage",
         "sqs:GetQueueAttributes",
         "sqs:DeleteMessage"


### PR DESCRIPTION
When you're doing cross account KMS, you need permissions on both ends.
I've updated TDR so it needs doing in the lambda policy
