### PR TITLE
Add S3 permissions and env vars

### DIFF
--- a/tdr_preingest.tf
+++ b/tdr_preingest.tf
@@ -90,6 +90,7 @@ module "dr2_preingest_tdr_package_builder_lambda" {
       lambda_name              = local.tdr_package_builder_lambda_name
       dynamo_db_lock_table_arn = module.ingest_lock_table.table_arn
       gsi_name                 = local.ingest_lock_table_group_id_gsi_name
+      raw_cache_bucket_name    = local.ingest_raw_cache_bucket_name
     })
   }
   memory_size = local.java_lambda_memory_size
@@ -97,6 +98,7 @@ module "dr2_preingest_tdr_package_builder_lambda" {
   plaintext_env_vars = {
     DDB_LOCK_TABLE              = local.ingest_lock_dynamo_table_name
     LOCK_DDB_TABLE_GROUP_ID_IDX = local.ingest_lock_table_group_id_gsi_name
+    RAW_CACHE_BUCKET            = local.ingest_raw_cache_bucket_name
   }
   tags = {
     Name = local.tdr_package_builder_lambda_name

--- a/templates/iam_policy/preingest_tdr_package_builder_policy.json.tpl
+++ b/templates/iam_policy/preingest_tdr_package_builder_policy.json.tpl
@@ -14,6 +14,18 @@
     },
     {
       "Action": [
+        "s3:PutObject*",
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${raw_cache_bucket_name}",
+        "arn:aws:s3:::${raw_cache_bucket_name}/*"
+      ],
+      "Sid": "readWriteIngestRawCache"
+    },
+    {
+      "Action": [
         "logs:PutLogEvents",
         "logs:CreateLogStream",
         "logs:CreateLogGroup"


### PR DESCRIPTION
The package builder needs to read the TDR metadata from S3 and write our
metadata out.
I've added the bucket as an environment variable rather than read it out
of one of the lock table messages.
