### PR TITLE
Preingest sfn fixes

### DIFF
--- a/templates/sfn/preingest_tdr_sfn_definition.json.tpl
+++ b/templates/sfn/preingest_tdr_sfn_definition.json.tpl
@@ -10,7 +10,6 @@
     "Invoke Package Builder Lambda": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
-      "OutputPath": "$.Payload",
       "Parameters": {
         "Payload.$": "$",
         "FunctionName": "arn:aws:lambda:eu-west-2:${account_id}:function:${package_builder_lambda_name}"
@@ -34,7 +33,7 @@
         "batchId.$": "$.Payload.batchId",
         "retryCount.$": "$.Payload.retryCount",
         "retrySfnArn.$": "$$.StateMachine.Id",
-        "packageMetadata.$": "$.Payload.packageMetadata"
+        "metadataPackage.$": "$.Payload.packageMetadata"
       }
     },
     "Start Ingest Step Function": {


### PR DESCRIPTION
We shouldn't have an output path and the ingest step function is
expected metadataPackage, not packageMetadata.

I will change the package builder to match at some point.
