### PR TITLE
Add the main cc queue.

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -365,6 +365,8 @@ module "cloudwatch_alarm_event_bridge_rule" {
       module.dr2_ingest_parsed_court_document_event_handler_sqs.dlq_cloudwatch_message_visible_alarm_arn,
       module.dr2_preservica_config_queue.queue_cloudwatch_message_visible_alarm_arn,
       module.dr2_preservica_config_queue.dlq_cloudwatch_message_visible_alarm_arn,
+      module.dr2_custodial_copy_queue.queue_cloudwatch_message_visible_alarm_arn,
+      module.dr2_custodial_copy_queue.dlq_cloudwatch_message_visible_alarm_arn,
       module.dr2_custodial_copy_db_builder_queue.queue_cloudwatch_message_visible_alarm_arn,
       module.dr2_custodial_copy_db_builder_queue.dlq_cloudwatch_message_visible_alarm_arn,
       module.dr2_custodial_copy_notifications_queue.queue_cloudwatch_message_visible_alarm_arn,


### PR DESCRIPTION
We're not getting alerts when there are errors in the main custodial
copy queue. This should sort it.
