### PR TITLE
DR2-1889 FIFO queue and creator lambda

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -43,7 +43,8 @@ locals {
     local.rotate_preservation_system_password_name,
     local.ingest_start_workflow_lambda_name,
     local.ingest_upsert_archive_folders_lambda_name,
-    local.ingest_workflow_monitor_lambda_name
+    local.ingest_workflow_monitor_lambda_name,
+    local.ingest_queue_creator_name
   ]
 }
 resource "random_password" "preservica_password" {
@@ -367,6 +368,8 @@ module "cloudwatch_alarm_event_bridge_rule" {
       module.dr2_preservica_config_queue.dlq_cloudwatch_message_visible_alarm_arn,
       module.dr2_custodial_copy_queue.queue_cloudwatch_message_visible_alarm_arn,
       module.dr2_custodial_copy_queue.dlq_cloudwatch_message_visible_alarm_arn,
+      module.dr2_custodial_copy_queue_creator_queue.queue_cloudwatch_message_visible_alarm_arn,
+      module.dr2_custodial_copy_queue_creator_queue.dlq_cloudwatch_message_visible_alarm_arn,
       module.dr2_custodial_copy_db_builder_queue.queue_cloudwatch_message_visible_alarm_arn,
       module.dr2_custodial_copy_db_builder_queue.dlq_cloudwatch_message_visible_alarm_arn,
       module.dr2_custodial_copy_notifications_queue.queue_cloudwatch_message_visible_alarm_arn,

--- a/custodial_copy.tf
+++ b/custodial_copy.tf
@@ -22,7 +22,7 @@ resource "aws_iam_group" "custodial_copy_group" {
 
 resource "aws_iam_group_policy" "custodial_copy_group_policy" {
   group = aws_iam_group.custodial_copy_group.name
-  name  = "${local.environment}-dr2-custodial-copy-policy"
+  name  = "${local.environment}-dr2-c.ustodial-copy-policy"
   policy = templatefile("${path.module}/templates/iam_policy/custodial_copy_policy.json.tpl", {
     account_id                 = data.aws_caller_identity.current.account_id
     secrets_manager_secret_arn = aws_secretsmanager_secret.preservica_secret.arn
@@ -46,10 +46,10 @@ module "dr2_custodial_copy_db_builder_queue" {
 module "dr2_custodial_copy_queue" {
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = local.custodial_copy_name
-  sqs_policy = templatefile("./templates/sqs/sns_send_message_policy.json.tpl", {
+  fifo_queue = true
+  sqs_policy = templatefile("./templates/sqs/sqs_access_policy.json.tpl", {
     account_id = var.account_number,
     queue_name = local.custodial_copy_name
-    topic_arn  = local.entity_event_topic_arn
   })
   encryption_type = local.sse_encryption
 }

--- a/custodial_copy.tf
+++ b/custodial_copy.tf
@@ -22,7 +22,7 @@ resource "aws_iam_group" "custodial_copy_group" {
 
 resource "aws_iam_group_policy" "custodial_copy_group_policy" {
   group = aws_iam_group.custodial_copy_group.name
-  name  = "${local.environment}-dr2-c.ustodial-copy-policy"
+  name  = "${local.environment}-dr2-custodial-copy-policy"
   policy = templatefile("${path.module}/templates/iam_policy/custodial_copy_policy.json.tpl", {
     account_id                 = data.aws_caller_identity.current.account_id
     secrets_manager_secret_arn = aws_secretsmanager_secret.preservica_secret.arn

--- a/custodial_copy_queue_creator.tf
+++ b/custodial_copy_queue_creator.tf
@@ -1,0 +1,42 @@
+locals {
+  ingest_queue_creator_name = "${local.environment}-dr2-custodial-copy-queue-creator"
+}
+
+module "dr2_custodial_copy_queue_creator_queue" {
+  source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
+  queue_name = local.ingest_queue_creator_name
+  sqs_policy = templatefile("./templates/sqs/sns_send_message_policy.json.tpl", {
+    account_id = var.account_number,
+    queue_name = local.ingest_queue_creator_name
+    topic_arn  = local.entity_event_topic_arn
+  })
+  encryption_type = local.sse_encryption
+}
+
+module "dr2_custodial_copy_queue_creator_lambda" {
+  source        = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"
+  function_name = local.ingest_queue_creator_name
+  handler       = "uk.gov.nationalarchives.custodialcopyqueuecreator.Lambda::handleRequest"
+  policies = {
+    dr2_custodial_copy_queue_creator_policy = templatefile("${path.module}/templates/iam_policy/custodial_copy_queue_creator_policy.json.tpl", {
+      account_id                 = data.aws_caller_identity.current.account_id
+      lambda_name                = local.ingest_queue_creator_name
+      custodial_copy_fifo_queue  = module.dr2_custodial_copy_queue.sqs_arn
+      queue_creator_input_queue  = module.dr2_custodial_copy_queue_creator_queue.sqs_arn
+      secrets_manager_secret_arn = aws_secretsmanager_secret.preservica_secret.arn
+    })
+  }
+  timeout_seconds = 180
+  memory_size     = local.java_lambda_memory_size
+  runtime         = local.java_runtime
+  tags            = {}
+  vpc_config = {
+    subnet_ids         = module.vpc.private_subnets
+    security_group_ids = [module.outbound_https_access_only.security_group_id]
+  }
+  plaintext_env_vars = {
+    PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_secret.name
+    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
+    OUTPUT_QUEUE           = module.dr2_custodial_copy_queue.sqs_queue_url
+  }
+}

--- a/deploy_roles.tf
+++ b/deploy_roles.tf
@@ -28,6 +28,7 @@ module "deploy_lambda_policy" {
         module.ingest_find_existing_asset.lambda_arn,
         module.dr2_ip_lock_checker_lambda.lambda_arn,
         module.dr2_ingest_parsed_court_document_event_handler_lambda.lambda_arn,
+        module.dr2_custodial_copy_queue_creator_lambda.lambda_arn,
         module.dr2_entity_event_generator_lambda.lambda_arn,
         module.dr2_ingest_mapper_lambda.lambda_arn,
         module.dr2_ingest_asset_opex_creator_lambda.lambda_arn,

--- a/entity_event_generator.tf
+++ b/entity_event_generator.tf
@@ -68,6 +68,6 @@ module "dr2_entity_event_generator_topic" {
   tags       = {}
   topic_name = local.entity_event_topic_name
   sqs_subscriptions = {
-    custodial_copy_queue = module.dr2_custodial_copy_queue.sqs_arn
+    custodial_copy_queue_creator_queue = module.dr2_custodial_copy_queue_creator_queue.sqs_arn
   }
 }

--- a/templates/iam_policy/custodial_copy_queue_creator_policy.json.tpl
+++ b/templates/iam_policy/custodial_copy_queue_creator_policy.json.tpl
@@ -1,0 +1,42 @@
+{
+  "Statement": [
+    {
+      "Action": "secretsmanager:GetSecretValue",
+      "Effect": "Allow",
+      "Resource": "${secrets_manager_secret_arn}",
+      "Sid": "readSecretsManager"
+    },
+    {
+      "Action": [
+        "sqs:SendMessage"
+      ],
+      "Effect": "Allow",
+      "Resource": "${custodial_copy_fifo_queue}",
+      "Sid": "sendSqsMessage"
+    },
+    {
+      "Action": [
+        "sqs:DeleteMessage",
+        "sqs:ReceiveMessage",
+        "sqs:GetQueueAttributes"
+      ],
+      "Effect": "Allow",
+      "Resource": "${queue_creator_input_queue}",
+      "Sid": "deleteSqsMessage"
+    },
+    {
+      "Action": [
+        "logs:PutLogEvents",
+        "logs:CreateLogStream",
+        "logs:CreateLogGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/aws/lambda/${lambda_name}:*:*",
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/aws/lambda/${lambda_name}:*"
+      ],
+      "Sid": "writeLogs"
+    }
+  ],
+  "Version": "2012-10-17"
+}


### PR DESCRIPTION
This creates the lambda which will add the IO id as the message group id
and creates the queue which triggers it.

I've updated the entity event topic to send to the new queue and updated
the existing custodial copy queue to be a fifo queue.

I've added the new sqs queue to the alarms and added the lambda to the
deploy policy.

This needs
https://github.com/nationalarchives/da-terraform-modules/pull/67 before
this will work.
