### PR TITLE
Increase lambda timeout.

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -19,7 +19,7 @@ locals {
   tre_prod_judgment_role                               = "arn:aws:iam::${module.tre_config.account_numbers["prod"]}:role/prod-tre-editorial-judgment-out-copier"
   java_runtime                                         = "java21"
   java_lambda_memory_size                              = 512
-  java_timeout_seconds                                 = 60
+  java_timeout_seconds                                 = 180
   python_runtime                                       = "python3.12"
   python_lambda_memory_size                            = 128
   python_timeout_seconds                               = 30


### PR DESCRIPTION
We're getting timeout errors on the ingest mapper for TDR transfers of
1000 files.

This will just increase all the lambda timeouts which I think is fine.

This is probably not the final value, we just need to do some testing to
see what the best values are.
