### PR TITLE
DR2-1896 Set reserved concurrency and timeout.

### DIFF
--- a/entity_event_generator.tf
+++ b/entity_event_generator.tf
@@ -25,10 +25,11 @@ module "dr2_entity_event_generator_lambda" {
       sns_arn                    = local.entity_event_topic_arn
     })
   }
-  timeout_seconds = 180
-  memory_size     = local.java_lambda_memory_size
-  runtime         = local.java_runtime
-  tags            = {}
+  timeout_seconds      = 60
+  memory_size          = local.java_lambda_memory_size
+  runtime              = local.java_runtime
+  tags                 = {}
+  reserved_concurrency = 1
   lambda_invoke_permissions = {
     "events.amazonaws.com" = module.dr2_entity_event_cloudwatch_event.event_arn
   }


### PR DESCRIPTION
Because the reserved concurrency wasn't set, we were sometimes getting
multiple lambdas reading Preservica at the same time and publishing the
messages more than once.

Also, we don't want this running over 60 seconds and having another
lambda read from Preservica before we've had a chance to update Dynamo
