### PR TITLE
Reconcile on workflow failure.

### DIFF
--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -425,28 +425,26 @@
         "duplicatedAssets.$": "$.Payload.duplicatedAssets"
       },
       "ResultPath": "$.WorkflowResult",
-      "Next": "Check workflow status and get Succeeded, Failed and Duplicated asset ids"
+      "Next": "Check workflow status"
     },
-    "Check workflow status and get Succeeded, Failed and Duplicated asset ids": {
+    "Check workflow status": {
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.WorkflowResult.status",
-          "StringEquals": "Failed",
-          "Next": "Job Failed"
-        },
-        {
-          "Variable": "$.WorkflowResult.status",
-          "StringEquals": "Succeeded",
+          "Or": [
+            {
+              "Variable": "$.WorkflowResult.status",
+              "StringEquals": "Failed"
+            },
+            {
+              "Variable": "$.WorkflowResult.status",
+              "StringEquals": "Succeeded"
+            }
+          ],
           "Next": "Map over each assetId and reconcile"
         }
       ],
-      "Default": "Wait 1 minute"
-    },
-    "Wait 1 minute": {
-      "Type": "Wait",
-      "Next": "Get workflow status",
-      "Seconds": 60
+      "Default": "Wait 5 minutes before getting status"
     },
     "Job Failed": {
       "Type": "Fail",


### PR DESCRIPTION
If the Preservica workflow fails, some assets may have been ingested and
we want these to progress and send their complete messages which they
won't if the step function fails.

The reconciler will return errors for the ones that haven't ingested.

I've reused the wait 5 minutes step just to tidy things up a bit. Most
ingests happen well before that and if not, another 5 minutes isn't
going to matter much.

I've also shortened the name of the state because the really wide boxes
make it difficult to see what's going on.
