### PR TITLE
Increase court document handler memory

### DIFF
--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -72,7 +72,7 @@ module "dr2_ingest_parsed_court_document_event_handler_lambda" {
       dynamo_db_lock_table_arn                             = module.ingest_lock_table.table_arn
     })
   }
-  memory_size = local.java_lambda_memory_size
+  memory_size = 1024
   runtime     = local.java_runtime
   plaintext_env_vars = {
     OUTPUT_BUCKET          = local.ingest_raw_cache_bucket_name


### PR DESCRIPTION
We had a failed judgment on prod because the lambda ran out of memory.
I suspect it was because there was a 12Mb log file in there and we have
to parse everything in the tar.gz file.

We could look into why this happened and try to fix the code but I don't
want to dedicate time to dealing with tar.gz files so I'll apply 21st
century solutions and throw more memory at it.
