### PR TITLE
DR2-1626 Add new environment variables for Lambda functions using standardised naming

### DIFF
--- a/copy_files_from_tdr.tf
+++ b/copy_files_from_tdr.tf
@@ -26,8 +26,10 @@ module "dr2_copy_files_from_tdr_lambda" {
   memory_size = local.python_lambda_memory_size
   runtime     = local.python_runtime
   plaintext_env_vars = {
-    DESTINATION_BUCKET = local.ingest_raw_cache_bucket_name
-    DESTINATION_QUEUE  = local.tdr_aggregator_queue_url
+    DESTINATION_BUCKET = local.ingest_raw_cache_bucket_name # Remove in DR2-1626/2
+    DESTINATION_QUEUE  = local.tdr_aggregator_queue_url     # Remove in DR2-1626/2
+    OUTPUT_BUCKET_NAME = local.ingest_raw_cache_bucket_name
+    OUTPUT_QUEUE_URL   = local.tdr_aggregator_queue_url
   }
   tags = {
     Name = local.copy_files_from_tdr_name

--- a/custodial_copy_notifications.tf
+++ b/custodial_copy_notifications.tf
@@ -50,6 +50,7 @@ module "dr2_custodial_copy_ingest_lambda" {
   runtime         = local.python_runtime
   tags            = {}
   plaintext_env_vars = {
-    DYNAMO_TABLE_NAME = local.files_dynamo_table_name
+    FILES_DDB_TABLE   = local.files_dynamo_table_name
+    DYNAMO_TABLE_NAME = local.files_dynamo_table_name # Remove in DR2-1626/2
   }
 }

--- a/custodial_copy_queue_creator.tf
+++ b/custodial_copy_queue_creator.tf
@@ -37,6 +37,7 @@ module "dr2_custodial_copy_queue_creator_lambda" {
   plaintext_env_vars = {
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_read_metadata.name
     PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
-    OUTPUT_QUEUE           = module.dr2_custodial_copy_queue.sqs_queue_url
+    OUTPUT_QUEUE           = module.dr2_custodial_copy_queue.sqs_queue_url # Remove in DR2-1626/2
+    OUTPUT_QUEUE_URL       = module.dr2_custodial_copy_queue.sqs_queue_url
   }
 }

--- a/entity_event_generator.tf
+++ b/entity_event_generator.tf
@@ -38,10 +38,12 @@ module "dr2_entity_event_generator_lambda" {
     security_group_ids = [module.outbound_https_access_only.security_group_id]
   }
   plaintext_env_vars = {
-    PRESERVICA_SECRET_NAME       = aws_secretsmanager_secret.preservica_read_metadata.name
-    ENTITY_EVENT_TOPIC_ARN       = local.entity_event_topic_arn
-    LAST_EVENT_ACTION_TABLE_NAME = local.last_polled_table_name
+    ENTITY_EVENT_TOPIC_ARN       = local.entity_event_topic_arn # Remove in DR2-1626/2
+    LAST_EVENT_ACTION_TABLE_NAME = local.last_polled_table_name # Remove in DR2-1626/2
+    LAMBDA_STATE_DDB_TABLE       = local.last_polled_table_name
     PRESERVICA_API_URL           = data.aws_ssm_parameter.preservica_url.value
+    PRESERVICA_SECRET_NAME       = aws_secretsmanager_secret.preservica_read_metadata.name
+    OUTPUT_TOPIC_ARN             = local.entity_event_topic_arn
   }
 }
 

--- a/get_latest_preservica_version.tf
+++ b/get_latest_preservica_version.tf
@@ -35,10 +35,13 @@ module "dr2_get_latest_preservica_version_lambda" {
   }
 
   plaintext_env_vars = {
+    LAMBDA_STATE_DDB_TABLE                = local.dr2_preservica_version_table_name
+    OUTPUT_TOPIC_ARN                      = local.latest_preservica_version_event_topic_arn
+    PRESERVICA_API_URL                    = data.aws_ssm_parameter.demo_preservica_url.value
     PRESERVICA_SECRET_NAME                = aws_secretsmanager_secret.demo_preservica_secret.name
-    PRESERVICA_VERSION_EVENT_TOPIC_ARN    = local.latest_preservica_version_event_topic_arn
-    CURRENT_PRESERVICA_VERSION_TABLE_NAME = local.dr2_preservica_version_table_name
-    PRESERVICA_DEMO_API_URL               = data.aws_ssm_parameter.demo_preservica_url.value
+    PRESERVICA_VERSION_EVENT_TOPIC_ARN    = local.latest_preservica_version_event_topic_arn  # Remove in DR2-1626/2
+    CURRENT_PRESERVICA_VERSION_TABLE_NAME = local.dr2_preservica_version_table_name          # Remove in DR2-1626/2
+    PRESERVICA_DEMO_API_URL               = data.aws_ssm_parameter.demo_preservica_url.value # Remove in DR2-1626/2
   }
 }
 

--- a/ingest_asset_opex_creator.tf
+++ b/ingest_asset_opex_creator.tf
@@ -21,9 +21,12 @@ module "dr2_ingest_asset_opex_creator_lambda" {
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
   plaintext_env_vars = {
-    DYNAMO_TABLE_NAME  = local.files_dynamo_table_name
-    DYNAMO_GSI_NAME    = local.files_table_batch_parent_global_secondary_index_name
-    DESTINATION_BUCKET = local.ingest_staging_cache_bucket_name
+    DYNAMO_TABLE_NAME                    = local.files_dynamo_table_name                              # Remove in DR2-1626/2
+    DYNAMO_GSI_NAME                      = local.files_table_batch_parent_global_secondary_index_name # Remove in DR2-1626/2
+    DESTINATION_BUCKET                   = local.ingest_staging_cache_bucket_name                     # Remove in DR2-1626/2
+    FILES_DDB_TABLE                      = local.files_dynamo_table_name
+    FILES_DDB_TABLE_BATCHPARENT_GSI_NAME = local.files_table_batch_parent_global_secondary_index_name
+    OUTPUT_BUCKET_NAME                   = local.ingest_staging_cache_bucket_name
   }
   tags = {
     Name = local.ingest_asset_opex_creator_lambda_name

--- a/ingest_asset_reconciler.tf
+++ b/ingest_asset_reconciler.tf
@@ -20,11 +20,14 @@ module "dr2_ingest_asset_reconciler_lambda" {
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
   plaintext_env_vars = {
-    PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_read_metadata.name
-    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
-    DYNAMO_TABLE_NAME      = local.files_dynamo_table_name
-    DYNAMO_GSI_NAME        = local.files_table_batch_parent_global_secondary_index_name
-    DYNAMO_LOCK_TABLE_NAME = local.ingest_lock_dynamo_table_name
+    FILES_DDB_TABLE                      = local.files_dynamo_table_name
+    FILES_DDB_TABLE_BATCHPARENT_GSI_NAME = local.files_table_batch_parent_global_secondary_index_name
+    LOCK_DDB_TABLE                       = local.ingest_lock_dynamo_table_name
+    PRESERVICA_API_URL                   = data.aws_ssm_parameter.preservica_url.value
+    PRESERVICA_SECRET_NAME               = aws_secretsmanager_secret.preservica_read_metadata.name
+    DYNAMO_TABLE_NAME                    = local.files_dynamo_table_name                              # Remove in DR2-1626/2
+    DYNAMO_GSI_NAME                      = local.files_table_batch_parent_global_secondary_index_name # Remove in DR2-1626/2
+    DYNAMO_LOCK_TABLE_NAME               = local.ingest_lock_dynamo_table_name                        # Remove in DR2-1626/2
   }
   vpc_config = {
     subnet_ids         = module.vpc.private_subnets

--- a/ingest_failed_notifications.tf
+++ b/ingest_failed_notifications.tf
@@ -20,9 +20,12 @@ module "dr2_ingest_failure_notifications_lambda" {
   runtime         = local.java_runtime
   tags            = {}
   plaintext_env_vars = {
-    DDB_LOCK_TABLE              = local.ingest_lock_dynamo_table_name
-    LOCK_DDB_TABLE_GROUP_ID_IDX = local.ingest_lock_table_group_id_gsi_name
-    TOPIC_ARN                   = module.dr2_notifications_sns.sns_arn
+    DDB_LOCK_TABLE                  = local.ingest_lock_dynamo_table_name       # Remove in DR2-1626/2
+    LOCK_DDB_TABLE_GROUP_ID_IDX     = local.ingest_lock_table_group_id_gsi_name # Remove in DR2-1626/2
+    TOPIC_ARN                       = module.dr2_notifications_sns.sns_arn      # Remove in DR2-1626/2
+    LOCK_DDB_TABLE                  = local.ingest_lock_dynamo_table_name
+    LOCK_DDB_TABLE_GROUPID_GSI_NAME = local.ingest_lock_table_group_id_gsi_name
+    OUTPUT_TOPIC_ARN                = module.dr2_notifications_sns.sns_arn
   }
   lambda_invoke_permissions = {
     "events.amazonaws.com" = module.failed_ingest_step_function_event_bridge_rule.rule_arn

--- a/ingest_files_change_handler.tf
+++ b/ingest_files_change_handler.tf
@@ -20,9 +20,12 @@ module "dr2_ingest_files_change_handler_lambda" {
   runtime         = local.java_runtime
   tags            = {}
   plaintext_env_vars = {
-    DYNAMO_TABLE_NAME = local.files_dynamo_table_name
-    DYNAMO_GSI_NAME   = local.files_table_batch_parent_global_secondary_index_name
-    TOPIC_ARN         = module.dr2_notifications_sns.sns_arn
+    DYNAMO_TABLE_NAME                    = local.files_dynamo_table_name                              # Remove in DR2-1626/2
+    DYNAMO_GSI_NAME                      = local.files_table_batch_parent_global_secondary_index_name # Remove in DR2-1626/2
+    TOPIC_ARN                            = module.dr2_notifications_sns.sns_arn                       # Remove in DR2-1626/2
+    FILES_DDB_TABLE                      = local.files_dynamo_table_name
+    FILES_DDB_TABLE_BATCHPARENT_GSI_NAME = local.files_table_batch_parent_global_secondary_index_name
+    OUTPUT_TOPIC_ARN                     = module.dr2_notifications_sns.sns_arn
   }
   dynamo_stream_config = {
     stream_arn = module.files_table.stream_arn

--- a/ingest_find_existing_asset.tf
+++ b/ingest_find_existing_asset.tf
@@ -20,9 +20,10 @@ module "ingest_find_existing_asset" {
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
   plaintext_env_vars = {
+    FILES_DDB_TABLE        = local.files_dynamo_table_name
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_read_metadata.name
     PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
-    DYNAMO_TABLE_NAME      = local.files_dynamo_table_name
+    DYNAMO_TABLE_NAME      = local.files_dynamo_table_name # Remove in DR2-1626/2
   }
   vpc_config = {
     subnet_ids         = module.vpc.private_subnets

--- a/ingest_folder_opex_creator.tf
+++ b/ingest_folder_opex_creator.tf
@@ -20,9 +20,12 @@ module "dr2_ingest_folder_opex_creator_lambda" {
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
   plaintext_env_vars = {
-    DYNAMO_TABLE_NAME = local.files_dynamo_table_name
-    DYNAMO_GSI_NAME   = local.files_table_batch_parent_global_secondary_index_name
-    BUCKET_NAME       = local.ingest_staging_cache_bucket_name
+    DYNAMO_TABLE_NAME                    = local.files_dynamo_table_name                              # Remove in DR2-1626/2
+    DYNAMO_GSI_NAME                      = local.files_table_batch_parent_global_secondary_index_name # Remove in DR2-1626/2
+    BUCKET_NAME                          = local.ingest_staging_cache_bucket_name                     # Remove in DR2-1626/2
+    FILES_DDB_TABLE                      = local.files_dynamo_table_name
+    FILES_DDB_TABLE_BATCHPARENT_GSI_NAME = local.files_table_batch_parent_global_secondary_index_name
+    OUTPUT_BUCKET_NAME                   = local.ingest_staging_cache_bucket_name
   }
   tags = {
     Name = local.ingest_folder_opex_creator_lambda_name

--- a/ingest_mapper.tf
+++ b/ingest_mapper.tf
@@ -19,8 +19,10 @@ module "dr2_ingest_mapper_lambda" {
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
   plaintext_env_vars = {
-    DYNAMO_TABLE_NAME   = local.files_dynamo_table_name
-    INGEST_STATE_BUCKET = local.ingest_state_bucket_name
+    DYNAMO_TABLE_NAME   = local.files_dynamo_table_name  # Remove in DR2-1626/2
+    INGEST_STATE_BUCKET = local.ingest_state_bucket_name # Remove in DR2-1626/2
+    FILES_DDB_TABLE     = local.files_dynamo_table_name
+    OUTPUT_BUCKET_NAME  = local.ingest_state_bucket_name
   }
   tags = {
     Name = local.ingest_mapper_lambda_name

--- a/ingest_parsed_court_document_event_handler.tf
+++ b/ingest_parsed_court_document_event_handler.tf
@@ -75,9 +75,12 @@ module "dr2_ingest_parsed_court_document_event_handler_lambda" {
   memory_size = 1024
   runtime     = local.java_runtime
   plaintext_env_vars = {
-    OUTPUT_BUCKET          = local.ingest_raw_cache_bucket_name
-    SFN_ARN                = module.dr2_ingest_step_function.step_function_arn
-    DYNAMO_LOCK_TABLE_NAME = local.ingest_lock_dynamo_table_name
+    OUTPUT_BUCKET          = local.ingest_raw_cache_bucket_name                # Remove in DR2-1626/2
+    SFN_ARN                = module.dr2_ingest_step_function.step_function_arn # Remove in DR2-1626/2
+    DYNAMO_LOCK_TABLE_NAME = local.ingest_lock_dynamo_table_name               # Remove in DR2-1626/2
+    INGEST_SFN_ARN         = module.dr2_ingest_step_function.step_function_arn
+    LOCK_DDB_TABLE         = local.ingest_lock_dynamo_table_name
+    OUTPUT_BUCKET_NAME     = local.ingest_raw_cache_bucket_name
   }
   tags = {
     Name = local.ingest_parsed_court_document_event_handler_lambda_name

--- a/ingest_upsert_archive_folders.tf
+++ b/ingest_upsert_archive_folders.tf
@@ -18,7 +18,8 @@ module "dr2_ingest_upsert_archive_folders_lambda" {
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
   plaintext_env_vars = {
-    ARCHIVE_FOLDER_TABLE_NAME = local.files_dynamo_table_name
+    ARCHIVE_FOLDER_TABLE_NAME = local.files_dynamo_table_name # Remove in DR2-1626/2
+    FILES_DDB_TABLE           = local.files_dynamo_table_name
     PRESERVICA_SECRET_NAME    = aws_secretsmanager_secret.preservica_read_update_metadata_insert_content.name
     PRESERVICA_API_URL        = data.aws_ssm_parameter.preservica_url.value
   }

--- a/tdr_preingest.tf
+++ b/tdr_preingest.tf
@@ -45,10 +45,11 @@ module "dr2_preingest_tdr_aggregator_lambda" {
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
   plaintext_env_vars = {
-    DDB_LOCK_TABLE                = local.ingest_lock_dynamo_table_name
-    PREINGEST_SFN_ARN             = local.preingest_sfn_arn
-    MAX_SECONDARY_BATCHING_WINDOW = local.tdr_aggregator_batching_window_seconds
+    DDB_LOCK_TABLE                = local.ingest_lock_dynamo_table_name # Remove in DR2-1626/2
+    LOCK_DDB_TABLE                = local.ingest_lock_dynamo_table_name
     MAX_BATCH_SIZE                = local.tdr_aggregator_batch_size
+    MAX_SECONDARY_BATCHING_WINDOW = local.tdr_aggregator_batching_window_seconds
+    PREINGEST_SFN_ARN             = local.preingest_sfn_arn
     SOURCE_SYSTEM                 = "TDR"
   }
   tags = {
@@ -96,9 +97,12 @@ module "dr2_preingest_tdr_package_builder_lambda" {
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
   plaintext_env_vars = {
-    DDB_LOCK_TABLE              = local.ingest_lock_dynamo_table_name
-    LOCK_DDB_TABLE_GROUP_ID_IDX = local.ingest_lock_table_group_id_gsi_name
-    RAW_CACHE_BUCKET            = local.ingest_raw_cache_bucket_name
+    DDB_LOCK_TABLE                  = local.ingest_lock_dynamo_table_name       # Remove in DR2-1626/2
+    LOCK_DDB_TABLE_GROUP_ID_IDX     = local.ingest_lock_table_group_id_gsi_name # Remove in DR2-1626/2
+    RAW_CACHE_BUCKET                = local.ingest_raw_cache_bucket_name        # Remove in DR2-1626/2
+    LOCK_DDB_TABLE                  = local.ingest_lock_dynamo_table_name
+    LOCK_DDB_TABLE_GROUPID_GSI_NAME = local.ingest_lock_table_group_id_gsi_name
+    OUTPUT_BUCKET_NAME              = local.ingest_raw_cache_bucket_name
   }
   tags = {
     Name = local.tdr_package_builder_lambda_name


### PR DESCRIPTION
Standardises environment variable names as
- FILES_DDB_TABLE
- FILES_DDB_TABLE_BATCHPARENT_GSI_NAME
- INGEST_SFN_ARN
- LAMBDA_STATE_DDB_TABLE
- LOCK_DDB_TABLE
- LOCK_DDB_TABLE_GROUPID_GSI_NAME
- OUTPUT_BUCKET_NAME
- OUTPUT_QUEUE_URL
- OUTPUT_TOPIC_ARN
- PRESERVICA_API_URL (problem for another day)
- PRESERVICA_SECRET_NAME (problem for another day)