### PR TITLE
Step function updates

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -328,7 +328,6 @@ module "dr2_ingest_step_function_policy" {
     ingest_asset_reconciler_lambda_name               = local.ingest_asset_reconciler_lambda_name
     ingest_lock_table_name                            = local.ingest_lock_dynamo_table_name
     ingest_lock_table_group_id_gsi_name               = local.ingest_lock_table_group_id_gsi_name
-    notifications_topic_name                          = local.notifications_topic_name
     ingest_staging_cache_bucket_name                  = local.ingest_staging_cache_bucket_name
     ingest_state_bucket_name                          = local.ingest_state_bucket_name
     ingest_sfn_name                                   = local.ingest_step_function_name

--- a/templates/iam_policy/ingest_step_function_policy.json.tpl
+++ b/templates/iam_policy/ingest_step_function_policy.json.tpl
@@ -10,8 +10,7 @@
         "sts:AssumeRole",
         "events:PutEvents",
         "dynamodb:Query",
-        "dynamodb:DeleteItem",
-        "sns:Publish"
+        "dynamodb:DeleteItem"
       ],
       "Resource": [
         "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_validate_generic_ingest_inputs_lambda_name}",
@@ -27,8 +26,8 @@
         "arn:aws:dynamodb:eu-west-2:${account_id}:table/${ingest_lock_table_name}",
         "arn:aws:dynamodb:eu-west-2:${account_id}:table/${ingest_lock_table_name}/index/${ingest_lock_table_group_id_gsi_name}",
         "arn:aws:states:eu-west-2:${account_id}:stateMachine:${ingest_sfn_name}",
-        "arn:aws:states:eu-west-2:${account_id}:execution:intg-dr2-ingest/MapOverEachFolderId:*",
-        "arn:aws:states:eu-west-2:${account_id}:execution:intg-dr2-ingest/MapOverEachAssetId:*",
+        "arn:aws:states:eu-west-2:${account_id}:execution:${ingest_sfn_name}/MapOverEachFolderId:*",
+        "arn:aws:states:eu-west-2:${account_id}:execution:${ingest_sfn_name}/MapOverEachAssetId:*",
         "arn:aws:events:eu-west-2:${account_id}:event-bus/default",
         "${tna_to_preservica_role_arn}"
       ]

--- a/templates/iam_policy/ingest_step_function_policy.json.tpl
+++ b/templates/iam_policy/ingest_step_function_policy.json.tpl
@@ -27,9 +27,8 @@
         "arn:aws:dynamodb:eu-west-2:${account_id}:table/${ingest_lock_table_name}",
         "arn:aws:dynamodb:eu-west-2:${account_id}:table/${ingest_lock_table_name}/index/${ingest_lock_table_group_id_gsi_name}",
         "arn:aws:states:eu-west-2:${account_id}:stateMachine:${ingest_sfn_name}",
-        "arn:aws:states:eu-west-2:${account_id}:execution:${ingest_sfn_name}/StagingCacheS3ObjectKeys:*",
-        "arn:aws:states:eu-west-2:${account_id}:execution:${ingest_sfn_name}:*",
-        "arn:aws:sns:eu-west-2:${account_id}:${notifications_topic_name}",
+        "arn:aws:states:eu-west-2:${account_id}:execution:intg-dr2-ingest/MapOverEachFolderId:*",
+        "arn:aws:states:eu-west-2:${account_id}:execution:intg-dr2-ingest/MapOverEachAssetId:*",
         "arn:aws:events:eu-west-2:${account_id}:event-bus/default",
         "${tna_to_preservica_role_arn}"
       ]
@@ -56,14 +55,17 @@
     },
     {
       "Action": [
-        "s3:GetObject"
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListMultipartUploadParts",
+        "s3:AbortMultipartUpload"
       ],
       "Effect": "Allow",
       "Resource": [
         "arn:aws:s3:::${ingest_state_bucket_name}",
         "arn:aws:s3:::${ingest_state_bucket_name}/*"
       ],
-      "Sid": "readIngestState"
+      "Sid": "readWriteIngestState"
     }
   ],
   "Version": "2012-10-17"

--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -539,7 +539,7 @@
               "Entries": [
                 {
                   "Detail": {
-                    "slackMessage.$": ":alert-noflash-slow: Reconcile failed for asset $.assetId"
+                    "slackMessage.$": ":alert-noflash-slow: Reconciliation failed for asset $.assetId. See the state output for the result key."
                   },
                   "DetailType": "DR2Message",
                   "EventBusName": "default",

--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -140,26 +140,7 @@
                 "BackoffRate": 2
               }
             ],
-            "ResultPath": "$.AssetExistsResult",
-            "Next": "Decide whether to continue ingesting asset or skip"
-          },
-          "Decide whether to continue ingesting asset or skip": {
-            "Type": "Choice",
-            "Choices": [
-              {
-                "Variable": "$.AssetExistsResult.assetExists",
-                "BooleanEquals": true,
-                "Next": "Skip ingesting asset"
-              },
-              {
-                "Variable": "$.AssetExistsResult.assetExists",
-                "BooleanEquals": false,
-                "Next": "Create Asset OPEX"
-              }
-            ]
-          },
-          "Skip ingesting asset": {
-            "Type": "Succeed"
+            "Next": "Create Asset OPEX"
           },
           "Create Asset OPEX": {
             "Type": "Task",
@@ -191,7 +172,11 @@
         }
       },
       "Next": "Map over each Folder Id",
-      "ResultPath": null
+      "ResultPath": null,
+      "ItemBatcher": {
+        "MaxItemsPerBatch": 20
+      },
+      "MaxConcurrency": 10
     },
     "Map over each Folder Id": {
       "Type": "Map",
@@ -519,7 +504,7 @@
                 "id": {
                   "S.$": "$.assetId"
                 },
-                "batchId" : {
+                "batchId": {
                   "S.$": "$$.Execution.Input.batchId"
                 }
               },
@@ -544,6 +529,7 @@
                 }
               }
             },
+            "ResultPath": null,
             "End": true
           },
           "Post failure message to Slack": {
@@ -553,7 +539,7 @@
               "Entries": [
                 {
                   "Detail": {
-                    "slackMessage.$": "$.reason"
+                    "slackMessage.$": ":alert-noflash-slow: Reconcile failed for asset $.assetId"
                   },
                   "DetailType": "DR2Message",
                   "EventBusName": "default",
@@ -570,7 +556,14 @@
           }
         }
       },
-      "Next": "Get number of items in lock table that have this groupId"
+      "Next": "Get number of items in lock table that have this groupId",
+      "ResultWriter": {
+        "Resource": "arn:aws:states:::s3:putObject",
+        "Parameters": {
+          "Bucket.$": "$.assets.bucket",
+          "Prefix": "reconcilerOutput"
+        }
+      }
     },
     "Get number of items in lock table that have this groupId": {
       "Type": "Task",


### PR DESCRIPTION
The distributed map which creates the asset opex needs to be batched otherwise we run out of lambda invocations.

The reconciler needs to stop outputing every failed child to Slack as this won’t work if there’s more than a few of them.

The reconciler also needs to send its output to S3 as it’s too large at the moment.

There are a few permissions updates needed and some of the SFN policy is out of date.
