### PR TITLE
Increase max session duration.

### DIFF
--- a/e2e_tests.tf
+++ b/e2e_tests.tf
@@ -16,7 +16,8 @@ module "dr2_run_e2e_tests_role" {
   policy_attachments = {
     run_e2e_tests_policy = module.dr2_e2e_tests_policy[count.index].policy_arn
   }
-  tags = {}
+  max_session_duration = 7200
+  tags                 = {}
 }
 
 module "dr2_e2e_tests_policy" {


### PR DESCRIPTION
I suspect that the tests weren't taking over an hour, they were just
broken but they might if we start chucking bigger ingests through so I'm
going to add this in anyway.
