### PR TITLE
DR2-1948 Delete staging cache bucket and provider.

### DIFF
--- a/root_provider.tf
+++ b/root_provider.tf
@@ -30,14 +30,3 @@ provider "aws" {
     }
   }
 }
-
-provider "aws" {
-  alias  = "datasync_tna_to_preservica"
-  region = "eu-west-2"
-  default_tags {
-    tags = {
-      Environment = local.environment
-      CreatedBy   = local.creator
-    }
-  }
-}


### PR DESCRIPTION
The changes to remove datasync are in prod so we don't need this any
more.

There'll be a manual step to empty the bucket before this can be
deployed.
