### PR TITLE
DR2-2034 Rename lambda policies

### DIFF
--- a/custodial_copy_notifications.tf
+++ b/custodial_copy_notifications.tf
@@ -35,7 +35,7 @@ module "dr2_custodial_copy_ingest_lambda" {
   function_name = local.custodial_copy_ingest_lambda_name
   handler       = "lambda_function.lambda_handler"
   policies = {
-    dr2_custodial_copy_policy = templatefile("${path.module}/templates/iam_policy/custodial_copy_lambda_policy.json.tpl", {
+    "${local.custodial_copy_ingest_lambda_name}-policy" = templatefile("${path.module}/templates/iam_policy/custodial_copy_lambda_policy.json.tpl", {
       account_id               = data.aws_caller_identity.current.account_id
       lambda_name              = local.custodial_copy_ingest_lambda_name
       dynamo_db_file_table_arn = module.files_table.table_arn

--- a/custodial_copy_queue_creator.tf
+++ b/custodial_copy_queue_creator.tf
@@ -19,7 +19,7 @@ module "dr2_custodial_copy_queue_creator_lambda" {
   function_name = local.ingest_queue_creator_name
   handler       = "uk.gov.nationalarchives.custodialcopyqueuecreator.Lambda::handleRequest"
   policies = {
-    dr2_custodial_copy_queue_creator_policy = templatefile("${path.module}/templates/iam_policy/custodial_copy_queue_creator_policy.json.tpl", {
+    "${local.ingest_queue_creator_name}-policy" = templatefile("${path.module}/templates/iam_policy/custodial_copy_queue_creator_policy.json.tpl", {
       account_id                 = data.aws_caller_identity.current.account_id
       lambda_name                = local.ingest_queue_creator_name
       custodial_copy_fifo_queue  = module.dr2_custodial_copy_queue.sqs_arn

--- a/entity_event_generator.tf
+++ b/entity_event_generator.tf
@@ -17,7 +17,7 @@ module "dr2_entity_event_generator_lambda" {
   function_name = local.entity_event_lambda_name
   handler       = "uk.gov.nationalarchives.entityeventgenerator.Lambda::handleRequest"
   policies = {
-    dr2_entity_event_policy = templatefile("${path.module}/templates/iam_policy/entity_event_lambda_policy.json.tpl", {
+    "${local.entity_event_lambda_name}-policy" = templatefile("${path.module}/templates/iam_policy/entity_event_lambda_policy.json.tpl", {
       account_id                 = data.aws_caller_identity.current.account_id
       lambda_name                = local.entity_event_lambda_name
       dynamo_db_file_table_arn   = module.dr2_entity_event_lambda_updated_since_query_start_datetime_table.table_arn

--- a/get_latest_preservica_version.tf
+++ b/get_latest_preservica_version.tf
@@ -18,7 +18,7 @@ module "dr2_get_latest_preservica_version_lambda" {
   function_name = local.get_latest_preservica_version
   handler       = "uk.gov.nationalarchives.getlatestpreservicaversion.Lambda::handleRequest"
   policies = {
-    dr2_get_latest_preservica_version_event_policy = templatefile("${path.module}/templates/iam_policy/get_latest_preservica_version_lambda_policy.json.tpl", {
+    "${local.get_latest_preservica_version}-policy" = templatefile("${path.module}/templates/iam_policy/get_latest_preservica_version_lambda_policy.json.tpl", {
       account_id                 = data.aws_caller_identity.current.account_id
       lambda_name                = local.get_latest_preservica_version
       dynamo_db_file_table_arn   = module.get_latest_preservica_version_lambda_dr2_preservica_version_table.table_arn

--- a/ingest_failed_notifications.tf
+++ b/ingest_failed_notifications.tf
@@ -7,7 +7,7 @@ module "dr2_ingest_failure_notifications_lambda" {
   function_name = local.ingest_failure_notifications_lambda_name
   handler       = "uk.gov.nationalarchives.ingestfailurenotifications.Lambda::handleRequest"
   policies = {
-    dr2_ingest_failure_notifications_policy = templatefile("${path.module}/templates/iam_policy/failure_notifications_policy.json.tpl", {
+    "${local.ingest_failure_notifications_lambda_name}-policy" = templatefile("${path.module}/templates/iam_policy/failure_notifications_policy.json.tpl", {
       account_id               = data.aws_caller_identity.current.account_id
       lambda_name              = local.ingest_failure_notifications_lambda_name
       dynamo_db_file_table_arn = module.ingest_lock_table.table_arn

--- a/ingest_files_change_handler.tf
+++ b/ingest_files_change_handler.tf
@@ -6,7 +6,7 @@ module "dr2_ingest_files_change_handler_lambda" {
   function_name = local.files_change_handler_name
   handler       = "uk.gov.nationalarchives.ingestfileschangehandler.Lambda::handleRequest"
   policies = {
-    dr2_ingest_files_change_handler_policy = templatefile("${path.module}/templates/iam_policy/file_change_handler_policy.json.tpl", {
+    "${local.files_change_handler_name}-policy" = templatefile("${path.module}/templates/iam_policy/file_change_handler_policy.json.tpl", {
       dynamo_db_file_table_stream_arn = module.files_table.stream_arn
       account_id                      = data.aws_caller_identity.current.account_id
       lambda_name                     = local.files_change_handler_name


### PR DESCRIPTION
We have a wildcard on the terraform policy for iam:* with a filter of
<env>* on role and policy names.
These names didn't match this pattern this will make them all match.
