### PR TITLE
Remove daily alarm and increase thresholds.

### DIFF
--- a/custodial_copy.tf
+++ b/custodial_copy.tf
@@ -40,7 +40,8 @@ module "dr2_custodial_copy_db_builder_queue" {
     queue_name = local.custodial_copy_db_builder_queue_name
     topic_arn  = local.custodial_copy_topic_arn
   })
-  encryption_type = local.sse_encryption
+  queue_cloudwatch_alarm_visible_messages_threshold = 50
+  encryption_type                                   = local.sse_encryption
 }
 
 module "dr2_custodial_copy_queue" {
@@ -51,6 +52,6 @@ module "dr2_custodial_copy_queue" {
     account_id = data.aws_caller_identity.current.account_id,
     queue_name = local.custodial_copy_name
   })
-  encryption_type             = local.sse_encryption
-  recurring_notification_hour = 10
+  queue_cloudwatch_alarm_visible_messages_threshold = 50
+  encryption_type                                   = local.sse_encryption
 }

--- a/custodial_copy_queue_creator.tf
+++ b/custodial_copy_queue_creator.tf
@@ -10,8 +10,9 @@ module "dr2_custodial_copy_queue_creator_queue" {
     queue_name = local.ingest_queue_creator_name
     topic_arn  = local.entity_event_topic_arn
   })
-  encryption_type    = local.sse_encryption
-  visibility_timeout = local.visibility_timeout
+  queue_cloudwatch_alarm_visible_messages_threshold = 50
+  encryption_type                                   = local.sse_encryption
+  visibility_timeout                                = local.visibility_timeout
 }
 
 module "dr2_custodial_copy_queue_creator_lambda" {


### PR DESCRIPTION
The daily alarm is not that helpful so that's being deleted.

The other custodial copy ones have had their threshold raised to 50
because it's fairly common that we get more than that for a single
ingest.

This has already been deployed.
