### PR TITLE
DR2-2086 Configure TDR Aggregator for larger message bursts

### DIFF
--- a/tdr_preingest.tf
+++ b/tdr_preingest.tf
@@ -1,13 +1,21 @@
 locals {
-  tdr_preingest_name                     = "${local.environment}-dr2-preingest-tdr"
-  tdr_aggregator_name                    = "${local.tdr_preingest_name}-aggregator"
-  tdr_aggregator_queue_arn               = "arn:aws:sqs:eu-west-2:${data.aws_caller_identity.current.account_id}:${local.tdr_aggregator_name}"
-  tdr_aggregator_batching_window_seconds = 300
-  tdr_aggregator_batch_size              = 10000
-  tdr_aggregator_queue_url               = "https://sqs.eu-west-2.amazonaws.com/${data.aws_caller_identity.current.account_id}/${local.tdr_aggregator_name}"
-  tdr_package_builder_lambda_name        = "${local.tdr_preingest_name}-package-builder"
-  preingest_sfn_arn                      = "arn:aws:states:eu-west-2:${data.aws_caller_identity.current.account_id}:stateMachine:${local.tdr_preingest_name}"
-  ingest_sfn_arn                         = "arn:aws:states:eu-west-2:${data.aws_caller_identity.current.account_id}:stateMachine:${local.ingest_step_function_name}"
+  tdr_preingest_name              = "${local.environment}-dr2-preingest-tdr"
+  tdr_aggregator_name             = "${local.tdr_preingest_name}-aggregator"
+  tdr_aggregator_queue_arn        = "arn:aws:sqs:eu-west-2:${data.aws_caller_identity.current.account_id}:${local.tdr_aggregator_name}"
+  tdr_aggregator_queue_url        = "https://sqs.eu-west-2.amazonaws.com/${data.aws_caller_identity.current.account_id}/${local.tdr_aggregator_name}"
+  tdr_package_builder_lambda_name = "${local.tdr_preingest_name}-package-builder"
+  preingest_sfn_arn               = "arn:aws:states:eu-west-2:${data.aws_caller_identity.current.account_id}:stateMachine:${local.tdr_preingest_name}"
+  ingest_sfn_arn                  = "arn:aws:states:eu-west-2:${data.aws_caller_identity.current.account_id}:stateMachine:${local.ingest_step_function_name}"
+
+  # Min time before starting ingest: tdr_aggregator_lambda_timeout_seconds + tdr_aggregator_secondary_grouping_window_seconds
+  # Max time before starting ingest: tdr_aggregator_primary_grouping_window_seconds + tdr_aggregator_lambda_timeout_seconds + tdr_aggregator_secondary_grouping_window_seconds
+  # (assumes that the Lambda doesn't fail)
+  tdr_aggregator_primary_grouping_window_seconds   = 300                                                                                                # How long the SQS Poller waits before invoking the Lambda after receiving the first message. <=300 for Lambda.
+  tdr_aggregator_lambda_timeout_seconds            = 60                                                                                                 # <=900 for Lambda.
+  tdr_aggregator_secondary_grouping_window_seconds = 180                                                                                                # Additional time we wait before starting preingest to allow multiple invocations to form a single group, this is added to the tdr_aggregator_lambda_timeout_seconds when we start a group.
+  tdr_aggregator_invocation_batch_size             = 10000                                                                                              # Max number of messages to invoke the Lambda with, but all messages need to be processed before the Lambda times out. <=10000 for Lambda.
+  tdr_aggregator_group_size                        = 10000                                                                                              # Max size of an aggregation group.
+  tdr_aggregator_queue_visibility_timeout          = local.tdr_aggregator_primary_grouping_window_seconds + local.tdr_aggregator_lambda_timeout_seconds # <=43200 for SQS.
 }
 
 module "dr2_preingest_tdr_aggregator_queue" {
@@ -18,7 +26,7 @@ module "dr2_preingest_tdr_aggregator_queue" {
     queue_name = local.tdr_aggregator_name
     topic_arn  = "arn:aws:sns:eu-west-2:${module.tdr_config.account_numbers[local.environment]}:tdr-external-notifications-${local.environment}"
   })
-  visibility_timeout = 180
+  visibility_timeout = local.tdr_aggregator_queue_visibility_timeout
   encryption_type    = "sse"
 }
 
@@ -26,13 +34,13 @@ module "dr2_preingest_tdr_aggregator_lambda" {
   source                       = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"
   function_name                = local.tdr_aggregator_name
   handler                      = "uk.gov.nationalarchives.preingesttdraggregator.Lambda::handleRequest"
-  sqs_queue_batching_window    = local.tdr_aggregator_batching_window_seconds
-  sqs_queue_mapping_batch_size = local.tdr_aggregator_batch_size
+  sqs_queue_batching_window    = local.tdr_aggregator_primary_grouping_window_seconds
+  sqs_queue_mapping_batch_size = local.tdr_aggregator_invocation_batch_size
   lambda_sqs_queue_mappings = [{
     sqs_queue_arn         = local.tdr_aggregator_queue_arn
     sqs_queue_concurrency = 2
   }]
-  timeout_seconds = local.java_timeout_seconds
+  timeout_seconds = local.tdr_aggregator_lambda_timeout_seconds
   policies = {
     "${local.tdr_aggregator_name}-policy" = templatefile("./templates/iam_policy/preingest_tdr_aggregator_policy.json.tpl", {
       account_id                 = data.aws_caller_identity.current.account_id
@@ -46,8 +54,8 @@ module "dr2_preingest_tdr_aggregator_lambda" {
   runtime     = local.java_runtime
   plaintext_env_vars = {
     LOCK_DDB_TABLE                = local.ingest_lock_dynamo_table_name
-    MAX_BATCH_SIZE                = local.tdr_aggregator_batch_size
-    MAX_SECONDARY_BATCHING_WINDOW = local.tdr_aggregator_batching_window_seconds
+    MAX_BATCH_SIZE                = local.tdr_aggregator_group_size
+    MAX_SECONDARY_BATCHING_WINDOW = local.tdr_aggregator_secondary_grouping_window_seconds
     PREINGEST_SFN_ARN             = local.preingest_sfn_arn
     SOURCE_SYSTEM                 = "TDR"
   }


### PR DESCRIPTION
Configures the TDR Aggregation workflow to handle larger bursts of messages. It's unknown how many messages the Lambda can handle in a single invocation before timeout so I've reduced this for now - it's better to have multiple invocations build a group than an invocation timeout as the messages will keep looping in Lambda/SQS until the ingest for that asset is unlocked.