### PR TITLE
DR2-2071 Use waitForTaskToken on ingest runner sub-workflow

### DIFF
--- a/ingest_flow_control.tf
+++ b/ingest_flow_control.tf
@@ -9,11 +9,12 @@ module "dr2_ingest_flow_control_lambda" {
   timeout_seconds = local.java_timeout_seconds
   policies = {
     "${local.ingest_flow_control_lambda_name}-policy" = templatefile("./templates/iam_policy/ingest_flow_control_policy.json.tpl", {
-      account_id                = data.aws_caller_identity.current.account_id
-      lambda_name               = local.ingest_flow_control_lambda_name
-      dynamo_db_queue_table_arn = module.ingest_queue_table.table_arn
-      ssm_parameter_arn         = aws_ssm_parameter.flow_control_config.arn
-      step_functions_arn        = module.dr2_ingest_step_function.step_function_arn
+      account_id                 = data.aws_caller_identity.current.account_id
+      lambda_name                = local.ingest_flow_control_lambda_name
+      dynamo_db_queue_table_arn  = module.ingest_queue_table.table_arn
+      ssm_parameter_arn          = aws_ssm_parameter.flow_control_config.arn
+      ingest_step_function_arn   = module.dr2_ingest_step_function.step_function_arn
+      workflow_step_function_arn = module.dr2_ingest_run_workflow_step_function.step_function_arn
     })
   }
 

--- a/templates/iam_policy/ingest_flow_control_policy.json.tpl
+++ b/templates/iam_policy/ingest_flow_control_policy.json.tpl
@@ -3,8 +3,9 @@
     {
       "Action": [
         "dynamodb:DeleteItem",
-        "dynamoDB:Query",
-        "dynamoDB:PutItem"
+        "dynamodb:Query",
+        "dynamodb:PutItem",
+        "dynamodb:BatchWriteItem"
       ],
       "Effect": "Allow",
       "Resource": "${dynamo_db_queue_table_arn}",
@@ -18,12 +19,19 @@
     },
     {
       "Action": [
-        "states:sendTaskSuccess",
+        "states:sendTaskSuccess"
+      ],
+      "Effect": "Allow",
+      "Resource": "${ingest_step_function_arn}",
+      "Sid": "sendTaskSuccess"
+    },
+    {
+      "Action": [
         "states:listExecutions"
       ],
       "Effect": "Allow",
-      "Resource": "${step_functions_arn}",
-      "Sid": "sendTaskSuccess"
+      "Resource": "${workflow_step_function_arn}",
+      "Sid": "listExecutions"
     },
     {
       "Action": [

--- a/templates/iam_policy/ingest_run_workflow_step_function_policy.json.tpl
+++ b/templates/iam_policy/ingest_run_workflow_step_function_policy.json.tpl
@@ -5,9 +5,11 @@
       "Effect": "Allow",
       "Action": [
         "states:RedriveExecution",
+        "states:SendTaskSuccess",
         "lambda:InvokeFunction"
       ],
       "Resource": [
+        "arn:aws:states:eu-west-2:${account_id}:stateMachine:${ingest_step_function_name}",
         "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_upsert_archive_folders_lambda_name}",
         "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_start_workflow_lambda_name}",
         "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_workflow_monitor_lambda_name}"

--- a/templates/sfn/ingest_run_workflow_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_run_workflow_sfn_definition.json.tpl
@@ -75,7 +75,7 @@
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "Payload": {
-          "executionId.$": "$$.Execution.Name"
+          "executionId.$": "$.batchId"
         },
         "FunctionName": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_workflow_monitor_lambda_name}"
       },
@@ -122,13 +122,18 @@
               "StringEquals": "Succeeded"
             }
           ],
-          "Next": "End Workflow and return WorkflowResult"
+          "Next": "SendTaskSuccess"
         }
       ],
       "Default": "Wait 5 minutes before getting status"
     },
-    "End Workflow and return WorkflowResult": {
-      "Type": "Pass",
+    "SendTaskSuccess": {
+      "Type": "Task",
+      "Parameters": {
+        "Output": "{}",
+        "TaskToken.$": "$.taskToken"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskSuccess",
       "End": true
     }
   }


### PR DESCRIPTION
* Make the run workflow step wait for a task token and pass the task token to the new step function
* Discard the output and return the input for that step
* Rename the run workflow step function invocation to ${ingest_sfn_name}-${random_uuid} This will let us redrive from the parent SFN
* Add a catch for Error States.ALL for both flow control lambdas and set the backoff rate to match the rest
* Update the permissions on the flow control lambda role as they were missing a couple
* Update the run workflow step function to send task success with the token passed as input.
* Update the policy to allow this.
* Send $.batchId instead of $$.Execution.Name to the start worfklow lambda.
* Add the ingest runner sub-workflow to the failed step function notifications.
* Use the arn in the message. At the moment it's hard coded to dr2-ingest which is unhelpful.
