### PR TITLE
DR2-2105 Ignore changes to the TDR aggregator trigger.

### DIFF
--- a/tdr_preingest.tf
+++ b/tdr_preingest.tf
@@ -39,6 +39,7 @@ module "dr2_preingest_tdr_aggregator_lambda" {
   lambda_sqs_queue_mappings = [{
     sqs_queue_arn         = local.tdr_aggregator_queue_arn
     sqs_queue_concurrency = 2
+    ignore_enabled_status = true
   }]
   timeout_seconds = local.tdr_aggregator_lambda_timeout_seconds
   policies = {


### PR DESCRIPTION
Terraform was overwriting it if we had it disabled.
