### PR TITLE
DR2-2089 Simplify and update retries

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -62,6 +62,7 @@ locals {
     local.tdr_aggregator_name,
     local.tdr_package_builder_lambda_name
   ]
+  retry_statement = jsonencode([{ ErrorEquals = ["States.ALL"], IntervalSeconds = 2, MaxAttempts = 6, BackoffRate = 2 }])
 }
 resource "random_password" "preservica_password" {
   length = 20
@@ -246,6 +247,7 @@ module "dr2_ingest_step_function" {
     ingest_files_table_name                           = local.files_dynamo_table_name
     ingest_queue_table_name                           = local.ingest_queue_dynamo_table_name
     ingest_flow_control_lambda_name                   = local.ingest_flow_control_lambda_name
+    retry_statement                                   = local.retry_statement
   })
   step_function_name = local.ingest_step_function_name
   step_function_role_policy_attachments = {
@@ -261,6 +263,7 @@ module "dr2_ingest_run_workflow_step_function" {
     ingest_upsert_archive_folders_lambda_name = local.ingest_upsert_archive_folders_lambda_name
     ingest_start_workflow_lambda_name         = local.ingest_start_workflow_lambda_name
     ingest_workflow_monitor_lambda_name       = local.ingest_workflow_monitor_lambda_name
+    retry_statement                           = local.retry_statement
   })
   step_function_name = local.ingest_run_workflow_step_function_name
   step_function_role_policy_attachments = {

--- a/tdr_preingest.tf
+++ b/tdr_preingest.tf
@@ -70,6 +70,7 @@ module "dr2_preingest_tdr_step_function" {
     ingest_step_function_arn    = local.ingest_sfn_arn
     account_id                  = data.aws_caller_identity.current.account_id
     package_builder_lambda_name = local.tdr_package_builder_lambda_name
+    retry_statement             = local.retry_statement
   })
   step_function_name = local.tdr_preingest_name
   step_function_role_policy_attachments = {

--- a/templates/sfn/ingest_run_workflow_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_run_workflow_sfn_definition.json.tpl
@@ -5,28 +5,7 @@
     "Create or update folders in Preservica": {
       "Type": "Task",
       "Resource": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_upsert_archive_folders_lambda_name}",
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException",
-            "Lambda.Unknown"
-          ],
-          "IntervalSeconds": 5,
-          "MaxAttempts": 15,
-          "BackoffRate": 1
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "Next": "Start workflow",
       "ResultPath": null
     },
@@ -40,28 +19,7 @@
           "executionId.$": "$.batchId"
         }
       },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException",
-            "Lambda.Unknown"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "ResultPath": null,
       "Next": "Wait 5 minutes before getting status"
     },
@@ -79,28 +37,7 @@
         },
         "FunctionName": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_workflow_monitor_lambda_name}"
       },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException",
-            "Lambda.Unknown"
-          ],
-          "IntervalSeconds": 1,
-          "MaxAttempts": 3,
-          "BackoffRate": 2
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "ResultSelector": {
         "status.$": "$.Payload.status",
         "mappedId.$": "$.Payload.mappedId"
@@ -133,6 +70,7 @@
         "Output": "{}",
         "TaskToken.$": "$.taskToken"
       },
+      "Retry": ${retry_statement},
       "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskSuccess",
       "End": true
     }

--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -5,28 +5,7 @@
     "Validate input": {
       "Type": "Task",
       "Resource": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_validate_generic_ingest_inputs_lambda_name}",
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException",
-            "Lambda.Unknown"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "Next": "Get metadata and update Files table"
     },
     "Get metadata and update Files table": {
@@ -37,28 +16,7 @@
         "metadataPackage.$": "$.metadataPackage",
         "executionName.$": "$$.Execution.Name"
       },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException",
-            "Lambda.Unknown"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "Next": "Map over each Asset Id"
     },
     "Map over each Asset Id": {
@@ -90,55 +48,13 @@
           "Check if asset has already been ingested": {
             "Type": "Task",
             "Resource": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_find_existing_asset_name_lambda_name}",
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "Lambda.ServiceException",
-                  "Lambda.AWSLambdaException",
-                  "Lambda.SdkClientException",
-                  "Lambda.TooManyRequestsException",
-                  "Lambda.Unknown"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              },
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              }
-            ],
+            "Retry": ${retry_statement},
             "Next": "Create Asset OPEX"
           },
           "Create Asset OPEX": {
             "Type": "Task",
             "Resource": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_asset_opex_creator_lambda_name}",
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "Lambda.ServiceException",
-                  "Lambda.AWSLambdaException",
-                  "Lambda.SdkClientException",
-                  "Lambda.TooManyRequestsException",
-                  "Lambda.Unknown"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              },
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              }
-            ],
+            "Retry": ${retry_statement},
             "End": true
           }
         }
@@ -178,28 +94,7 @@
           "Create Folder OPEX": {
             "Type": "Task",
             "Resource": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_folder_opex_creator_lambda_name}",
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "Lambda.ServiceException",
-                  "Lambda.AWSLambdaException",
-                  "Lambda.SdkClientException",
-                  "Lambda.TooManyRequestsException",
-                  "Lambda.Unknown"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              },
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              }
-            ],
+            "Retry": ${retry_statement},
             "End": true
           }
         }
@@ -213,28 +108,7 @@
       "Parameters": {
         "executionId.$": "$$.Execution.Name"
       },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException",
-            "Lambda.Unknown"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "ResultPath": null,
       "Next": "Enter flow controlled ingest"
     },
@@ -249,28 +123,7 @@
           "executionName.$": "$$.Execution.Name"
         }
       },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2,
-          "JitterStrategy": "FULL"
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "Next": "Start 'Run Workflow' Step Function"
     },
     "Start 'Run Workflow' Step Function": {
@@ -281,6 +134,7 @@
         "Name.$": "States.Format('{}-{}', $$.Execution.Name, States.UUID())",
         "Input.$": "States.JsonMerge($, States.StringToJson(States.Format('\\{\"{}\":\"{}\",\"{}\":\"{}\"\\}', 'AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID', $$.Execution.Id, 'taskToken', $$.Task.Token)), false)"
       },
+      "Retry": ${retry_statement},
       "ResultPath": null,
       "Next": "Exit flow controlled ingest"
     },
@@ -292,28 +146,7 @@
         "FunctionName": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_flow_control_lambda_name}",
         "Payload": {}
       },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2,
-          "JitterStrategy": "FULL"
-        },
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "Next": "Map over each assetId and reconcile"
     },
     "Map over each assetId and reconcile": {
@@ -345,28 +178,7 @@
           "Reconcile assetId and children": {
             "Type": "Task",
             "Resource": "arn:aws:lambda:eu-west-2:${account_id}:function:${ingest_asset_reconciler_lambda_name}",
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "Lambda.ServiceException",
-                  "Lambda.AWSLambdaException",
-                  "Lambda.SdkClientException",
-                  "Lambda.TooManyRequestsException",
-                  "Lambda.Unknown"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              },
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              }
-            ],
+            "Retry": ${retry_statement},
             "Next": "Check if Reconciliation succeeded and post to Slack if it didn't"
           },
           "Check if Reconciliation succeeded and post to Slack if it didn't": {
@@ -405,6 +217,7 @@
                 }
               }
             },
+            "Retry": ${retry_statement},
             "ResultPath": null,
             "Next": "Delete asset item from lock table"
           },
@@ -419,12 +232,14 @@
                 }
               }
             },
+            "Retry": ${retry_statement},
             "ResultPath": null,
             "End": true
           },
           "Post failure message to Slack": {
             "Type": "Task",
             "Resource": "arn:aws:states:::events:putEvents",
+            "Retry": ${retry_statement},
             "Parameters": {
               "Entries": [
                 {
@@ -467,6 +282,7 @@
           }
         }
       },
+      "Retry": ${retry_statement},
       "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
       "Next": "Check if number of items is 0"
     },
@@ -514,6 +330,7 @@
     "Retry pre-ingest step function": {
       "Type": "Task",
       "Resource": "arn:aws:states:::states:startExecution",
+      "Retry": ${retry_statement},
       "Parameters": {
         "StateMachineArn.$": "$$.Execution.Input.retrySfnArn",
         "Name.$": "$.newBatchId",

--- a/templates/sfn/preingest_tdr_sfn_definition.json.tpl
+++ b/templates/sfn/preingest_tdr_sfn_definition.json.tpl
@@ -14,19 +14,7 @@
         "Payload.$": "$",
         "FunctionName": "arn:aws:lambda:eu-west-2:${account_id}:function:${package_builder_lambda_name}"
       },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 1,
-          "MaxAttempts": 3,
-          "BackoffRate": 2
-        }
-      ],
+      "Retry": ${retry_statement},
       "Next": "Start Ingest Step Function",
       "ResultSelector": {
         "groupId.$": "$.Payload.groupId",
@@ -39,6 +27,7 @@
     "Start Ingest Step Function": {
       "Type": "Task",
       "Resource": "arn:aws:states:::states:startExecution",
+      "Retry": ${retry_statement},
       "Parameters": {
         "StateMachineArn": "${ingest_step_function_arn}",
         "Name.$": "$$.Execution.Name",


### PR DESCRIPTION
The States.ALL error should catch any error that happens within the step
function, either from our code or from AWS.

We're fairly sure we don't need the specific Lambda exceptions.

The SDK calls to Dynamo, EventBridge and StepFunctions didn't have
retries either. So I've changed the template json files to take a
parameter and passed in the same retry block for all of them.

This should cover everything.
