### PR TITLE
Update e2e-tests policy

### DIFF
--- a/sns_notifications.tf
+++ b/sns_notifications.tf
@@ -12,10 +12,7 @@ module "dr2_notifications_sns" {
     Name = local.notifications_topic_name
   }
   topic_name = local.notifications_topic_name
-  sqs_subscriptions = local.environment != "intg" ? {
+  sqs_subscriptions = {
     log_external_notifications_queue = module.dr2_external_notifications_queue.sqs_arn
-    } : {
-    log_external_notifications_queue = module.dr2_external_notifications_queue.sqs_arn,
-    e2e_tests_queue                  = module.dr2_e2e_tests_queue[0].sqs_arn
   }
 }

--- a/templates/iam_policy/e2e_tests_policy.json.tpl
+++ b/templates/iam_policy/e2e_tests_policy.json.tpl
@@ -23,21 +23,22 @@
     },
     {
       "Action": [
-        "sqs:ReceiveMessage",
-        "sqs:GetQueueAttributes",
-        "sqs:DeleteMessage"
-      ],
-      "Effect": "Allow",
-      "Resource": ["${copy_files_dlq}", "${e2e_tests_queue}"],
-      "Sid": "readSqs"
-    },
-    {
-      "Action": [
         "sqs:SendMessage"
       ],
       "Effect": "Allow",
-      "Resource": "${copy_files_from_tdr_queue}",
+      "Resource": ["${judgment_input_queue}", "${copy_files_from_tdr_queue}"],
       "Sid": "sendSqsMessage"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:StartLiveTail",
+        "logs:GetLogEvents"
+      ],
+      "Resource": [
+        "${external_notifications_log_group}",
+        "${copy_files_from_tdr_log_group}"
+      ]
     },
     {
       "Action": [


### PR DESCRIPTION
The e2e tests have changed and need some new permissions and don't need
old ones. We also don't need the e2e-tests queue any more.
