### PR TITLE
DR2-2190 Use correct input param.

### DIFF
--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -278,7 +278,7 @@
         "KeyConditionExpression": "groupId = :lookUpId",
         "ExpressionAttributeValues": {
           ":lookUpId": {
-            "S.$": "$$.Execution.Input.batchId"
+            "S.$": "$$.Execution.Input.groupId"
           }
         }
       },


### PR DESCRIPTION
The lock table contains the groupId, not the batchId, so this query
always returns zero results.
