### PR TITLE
DR2-2215 Use S3 locking.

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -28,6 +28,4 @@ jobs:
       ACCOUNT_NUMBER: ${{ secrets[needs.setup.outputs.account-number] }}
       SLACK_WEBHOOK: ${{ secrets[needs.setup.outputs.slack-webhook] }}
       TERRAFORM_ROLE: ${{ secrets[needs.setup.outputs.terraform-role] }}
-      STATE_BUCKET: ${{ secrets[needs.setup.outputs.state-bucket] }}
-      DYNAMO_TABLE: ${{ secrets[needs.setup.outputs.dynamo-table] }}
 

--- a/root_provider.tf
+++ b/root_provider.tf
@@ -15,10 +15,11 @@ module "tdr_config" {
 
 terraform {
   backend "s3" {
-    bucket  = "mgmt-dp-terraform-state"
-    key     = "terraform.state"
-    region  = "eu-west-2"
-    encrypt = true
+    bucket       = "mgmt-dp-terraform-state"
+    key          = "terraform.state"
+    region       = "eu-west-2"
+    encrypt      = true
+    use_lockfile = true
   }
 }
 provider "aws" {


### PR DESCRIPTION
Dynamo locking has been deprecated. This will use s3 instead.

Needs https://github.com/nationalarchives/dr2-github-actions/pull/36 before this can merge
