### PR TITLE
DR2-2139 Configure Ingest Flow Control

### DIFF
--- a/templates/ssm/ingest_flow_control_config.json.tpl
+++ b/templates/ssm/ingest_flow_control_config.json.tpl
@@ -1,5 +1,5 @@
 {
-  "maxConcurrency": 8,
+  "maxConcurrency": 5,
   "sourceSystems": [
     {
       "systemName": "TDR",


### PR DESCRIPTION
We have 2 environments and a single Job Queue server with 16 threads. We've been advised to use 10 threads in total for our activities, so limiting to 5 concurrent ingests per environment.