### PR TITLE
Use assetId not ioRef

### DIFF
--- a/post_ingest/post_ingest.tf
+++ b/post_ingest/post_ingest.tf
@@ -12,7 +12,7 @@ data "aws_caller_identity" "current" {}
 
 module "post_ingest_state_table" {
   source                         = "git::https://github.com/nationalarchives/da-terraform-modules//dynamo"
-  hash_key                       = { name = "ioRef", type = "S" }
+  hash_key                       = { name = "assetId", type = "S" }
   range_key                      = { name = "batchId", type = "S" }
   table_name                     = local.post_ingest_state_table_name
   server_side_encryption_enabled = false

--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -228,8 +228,8 @@
             "Parameters": {
               "TableName": "${post_ingest_table_name}",
               "Item": {
-                "ioRef": {
-                  "S.$": "$.ioRef"
+                "assetId": {
+                  "S.$": "$.assetId"
                 },
                 "batchId": {
                   "S.$": "$$.Execution.Input.batchId"


### PR DESCRIPTION
We can't use ioRef for the PK because the output messages need to have
our reference, not Preservicas.

The confirmer job will need to contact Preservica to get their reference
from ours
