### PR TITLE
Add ioRef as well.

### DIFF
--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -233,6 +233,9 @@
                 },
                 "batchId": {
                   "S.$": "$$.Execution.Input.batchId"
+                },
+                "ioRef": {
+                  "S.$": "$.ioRef"
                 }
               }
             },

--- a/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/templates/sfn/ingest_sfn_definition.json.tpl
@@ -234,8 +234,8 @@
                 "batchId": {
                   "S.$": "$$.Execution.Input.batchId"
                 },
-                "ioRef": {
-                  "S.$": "$.ioRef"
+                "input": {
+                  "S.$": "States.Format('\\{\"preservationSystemId\":\"{}\"\\}', $.ioRef)"
                 }
               }
             },


### PR DESCRIPTION
This way, the change handler can pass this to the CC confirmer which
will keep things much simpler.
