### PR TITLE
DR2-2258 Remove PRESERVICA_API_URL

### DIFF
--- a/custodial_copy_queue_creator.tf
+++ b/custodial_copy_queue_creator.tf
@@ -41,7 +41,6 @@ module "dr2_custodial_copy_queue_creator_lambda" {
   }
   plaintext_env_vars = {
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_read_metadata.name
-    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
     OUTPUT_QUEUE_URL       = module.dr2_custodial_copy_queue.sqs_queue_url
   }
 }

--- a/entity_event_generator.tf
+++ b/entity_event_generator.tf
@@ -39,7 +39,6 @@ module "dr2_entity_event_generator_lambda" {
   }
   plaintext_env_vars = {
     LAMBDA_STATE_DDB_TABLE = local.last_polled_table_name
-    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_read_metadata.name
     OUTPUT_TOPIC_ARN       = local.entity_event_topic_arn
   }

--- a/get_latest_preservica_version.tf
+++ b/get_latest_preservica_version.tf
@@ -37,7 +37,6 @@ module "dr2_get_latest_preservica_version_lambda" {
   plaintext_env_vars = {
     LAMBDA_STATE_DDB_TABLE = local.dr2_preservica_version_table_name
     OUTPUT_TOPIC_ARN       = local.latest_preservica_version_event_topic_arn
-    PRESERVICA_API_URL     = data.aws_ssm_parameter.demo_preservica_url.value
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.demo_preservica_secret.name
   }
 }

--- a/ingest_asset_reconciler.tf
+++ b/ingest_asset_reconciler.tf
@@ -23,7 +23,6 @@ module "dr2_ingest_asset_reconciler_lambda" {
     FILES_DDB_TABLE                      = local.files_dynamo_table_name
     FILES_DDB_TABLE_BATCHPARENT_GSI_NAME = local.files_table_batch_parent_global_secondary_index_name
     LOCK_DDB_TABLE                       = local.ingest_lock_dynamo_table_name
-    PRESERVICA_API_URL                   = data.aws_ssm_parameter.preservica_url.value
     PRESERVICA_SECRET_NAME               = aws_secretsmanager_secret.preservica_read_metadata.name
   }
   vpc_config = {

--- a/ingest_find_existing_asset.tf
+++ b/ingest_find_existing_asset.tf
@@ -22,7 +22,6 @@ module "ingest_find_existing_asset" {
   plaintext_env_vars = {
     FILES_DDB_TABLE        = local.files_dynamo_table_name
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_read_metadata.name
-    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
   }
   vpc_config = {
     subnet_ids         = module.vpc.private_subnets

--- a/ingest_start_workflow.tf
+++ b/ingest_start_workflow.tf
@@ -18,7 +18,6 @@ module "dr2_ingest_start_workflow_lambda" {
   runtime     = local.java_runtime
   plaintext_env_vars = {
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_secret.name
-    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
   }
   vpc_config = {
     subnet_ids         = module.vpc.private_subnets

--- a/ingest_upsert_archive_folders.tf
+++ b/ingest_upsert_archive_folders.tf
@@ -20,7 +20,6 @@ module "dr2_ingest_upsert_archive_folders_lambda" {
   plaintext_env_vars = {
     FILES_DDB_TABLE        = local.files_dynamo_table_name
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_read_update_metadata_insert_content.name
-    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
   }
   vpc_config = {
     subnet_ids         = module.vpc.private_subnets

--- a/ingest_workflow_monitor.tf
+++ b/ingest_workflow_monitor.tf
@@ -18,7 +18,6 @@ module "dr2_ingest_workflow_monitor_lambda" {
   runtime     = local.java_runtime
   plaintext_env_vars = {
     PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_secret.name
-    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
   }
   vpc_config = {
     subnet_ids         = module.vpc.private_subnets

--- a/rotate_preservation_system_password.tf
+++ b/rotate_preservation_system_password.tf
@@ -21,9 +21,6 @@ module "dr2_rotate_preservation_system_password_lambda" {
   }
   memory_size = local.java_lambda_memory_size
   runtime     = local.java_runtime
-  plaintext_env_vars = {
-    PRESERVICA_API_URL = data.aws_ssm_parameter.preservica_url.value
-  }
   vpc_config = {
     subnet_ids         = module.vpc.private_subnets
     security_group_ids = [module.outbound_https_access_only.security_group_id]


### PR DESCRIPTION
Once https://github.com/nationalarchives/dr2-ingest/pull/513 is merged
and deployed, this can be run.

We're now getting the API url from the secret so there's no need to have
it here
