### PR TITLE
Output the lambda arn

### DIFF
--- a/postingest/outputs.tf
+++ b/postingest/outputs.tf
@@ -11,5 +11,5 @@ output "postingest_confirmer_queue_arn" {
 }
 
 output "postingest_state_change_lambda_arn" {
-  value = module.dr2_state_change_lambda
+  value = module.dr2_state_change_lambda.lambda_arn
 }


### PR DESCRIPTION
Minor change to output the lambda arn instead of the whole object.
