### PR TITLE
Add delay of 15 minutes.

### DIFF
--- a/postingest/postingest.tf
+++ b/postingest/postingest.tf
@@ -49,6 +49,7 @@ module "dr2_custodial_copy_confirmer_queue" {
   queue_cloudwatch_alarm_visible_messages_threshold = 50
   visibility_timeout                                = 3600
   encryption_type                                   = "sse"
+  delay_seconds                                     = 900
 }
 
 


### PR DESCRIPTION
What is happening is that the messages are being sent to CC confirmer 2
minutes before they actually make it into CC and we then have to wait an
hour for it to try again.

This will delay the sending of the message for 15 minutes.
